### PR TITLE
Initial import of code for process forking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: scala
 
-before_script: cd landlordd
+before_script: 
+  - cd landlordd
+  - _JAVA_OPTIONS=
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: scala
 
 before_script: cd landlordd
-
-script: sbt test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: scala
 
 before_script: 
   - cd landlordd
-  - _JAVA_OPTIONS=
+  - unset _JAVA_OPTIONS
 

--- a/landlordd/.gitignore
+++ b/landlordd/.gitignore
@@ -1,0 +1,2 @@
+target/
+.ensime*

--- a/landlordd/.travis.yml
+++ b/landlordd/.travis.yml
@@ -1,3 +1,5 @@
 language: scala
 
 before_script: cd landlordd
+
+script: sbt test

--- a/landlordd/.travis.yml
+++ b/landlordd/.travis.yml
@@ -1,0 +1,3 @@
+language: scala
+
+before_script: cd landlordd

--- a/landlordd/bootstrap/src/main/java/com/github/huntc/landlord/Main.java
+++ b/landlordd/bootstrap/src/main/java/com/github/huntc/landlord/Main.java
@@ -1,0 +1,81 @@
+package com.github.huntc.landlord;
+
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.LinkedList;
+
+public class Main {
+  static {
+    Native.register(NativeLibrary.getProcess());
+  }
+
+  private static native int close(Integer fd);
+  
+  private static native int getpid();
+
+  private static native int getppid();
+
+  private static final int MAX_FDS = 1024; // Typical Linux soft limit for the max number of file descriptors
+
+  /*
+   * Get the file descriptors for the passed in pid assuming a procfs (https://en.wikipedia.org/wiki/Procfs).
+   */
+  private static List<Integer> getFds(Integer pid) {
+    List<Integer> fds = new LinkedList<>();
+    try {
+      DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get("/proc/" + pid + "/fd"));
+      try {
+        for (Path path: dirStream) {
+          try {
+            Integer fd = Integer.parseInt(path.getFileName().toString());
+            if (fds.size() < MAX_FDS) fds.add(fd); // Don't blow memory - constrain to a max
+          } catch (NumberFormatException e) {
+          }
+        }
+      } finally {
+        dirStream.close();
+      }
+    } catch (IOException e) {
+    }
+    return fds;
+  }
+
+  /*
+  * Close those file descriptors that are shared with our parent process.
+  */
+  private static void closeInheritedFds() {
+    List<Integer> parentFds = getFds(getppid());
+    List<Integer> ourFds = getFds(getpid());
+    parentFds.retainAll(ourFds);
+    parentFds
+      .stream()
+      .filter(fd -> fd > 2)
+      .forEach(fd -> close(fd)); // We don't want to close stdin/out/err
+  }
+
+  /*
+   * If we're operating on Linux then we will inherit or parent process file
+   * descriptors. We need to close them so that we don't run out. See
+   * https://github.com/brettwooldridge/NuProcess/issues/13#issuecomment-282071125
+   * for more background.
+   */
+  public static void main(String[] args) throws ClassNotFoundException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    if (System.getProperty("os.name").toLowerCase().startsWith("linux"))
+      closeInheritedFds();
+
+    Class<?> cls = Class.forName(args[0]);
+    Method meth = cls.getMethod("main", args.getClass());
+    meth.invoke(null, (Object)Arrays.copyOfRange(args, 1, args.length));
+  }
+}
+

--- a/landlordd/bootstrap/src/test/scala/com/github/huntc/landlord/MainSpec.scala
+++ b/landlordd/bootstrap/src/test/scala/com/github/huntc/landlord/MainSpec.scala
@@ -1,0 +1,21 @@
+package com.github.huntc.landlord
+
+import org.scalatest._
+
+object MainSpec {
+  var testMainArgs = Array.empty[String]
+}
+
+class MainSpec extends FlatSpec with Matchers {
+  import MainSpec._
+
+  "bootable main" should
+    "invoke the test main" in {
+      Main.main(Array("com.github.huntc.landlord.TestMain", "something"))
+      testMainArgs shouldBe Array("something")
+    }
+}
+
+object TestMain extends App {
+  MainSpec.testMainArgs = args
+}

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -1,0 +1,98 @@
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import scalariform.formatter.preferences._
+
+import Dependencies._
+
+lazy val bootstrap = project
+  .in(file("bootstrap"))
+  .settings(
+    name := "bootstrap",
+    libraryDependencies ++= Seq(
+      jna,
+      scalaTest % Test
+    ),
+    crossPaths := false,
+    autoScalaLibrary := false
+  )
+
+lazy val bootstrapLibPath = "extra/bootstrap.jar"
+
+lazy val daemon = project
+  .in(file("daemon"))
+  .settings(
+    name := "daemon",
+    libraryDependencies ++= Seq(
+      akkaContribExtra,
+      commonsCompress,
+      scopt,
+      akkaTestKit % Test,
+      scalaTest % Test
+    ),
+    resolvers += Resolvers.typesafeBintrayReleases,
+    compileOrder in Compile := CompileOrder.JavaThenScala,
+    compileOrder in Test := CompileOrder.Mixed,
+    unmanagedSourceDirectories in Compile := (javaSource in Compile).value :: Nil,
+    scriptClasspathOrdering := {
+      val assemblyFile = assembly.value
+      Seq(assemblyFile -> ("lib/" + assemblyFile.getName))
+    },
+    sourceGenerators in Compile += Def.task {
+      val versionFile = (sourceManaged in Compile).value / "Version.scala"
+      val versionSource =
+        s"""|package com.github.huntc.landlord
+            |
+            |object Version {
+            |  val executableScriptName = "${(executableScriptName in Universal).value}"
+            |  val current = "${version.value}"
+            |}
+            """.stripMargin
+      IO.write(versionFile, versionSource)
+      Seq(versionFile)
+    }.taskValue,
+    // Provide the test classes as resources for our tests
+    resourceGenerators in Test += Def.task {
+      val targetDir = (resourceManaged in Test).value
+      val testClassesMappings = {
+        val sourceDir = (classDirectory in Compile in test).value
+        (PathFinder(sourceDir).***).pair(Path.rebase(sourceDir, targetDir))
+      }
+      val bootstrapAssemblyMappings = {
+        val sourceAssembly = (assembly in bootstrap).value
+        Seq(sourceAssembly -> targetDir / "bootstrap-assembly.jar")
+      }
+      val mappings = testClassesMappings ++ bootstrapAssemblyMappings
+      IO.copy(mappings)
+      mappings.map(_._2)
+    }.dependsOn(compile in Compile in test).taskValue,
+    // Native packager
+    bashScriptExtraDefines += s"""addJava "-Dlandlordd.bootstrap-lib.path=$${app_home}/../$bootstrapLibPath"""",
+    executableScriptName := "landlordd",
+    mappings in Universal += {
+      val bootstrapAssembly = (assembly in bootstrap).value
+      bootstrapAssembly -> bootstrapLibPath
+    },
+    packageName in Universal := "landlord"
+  )
+  .enablePlugins(JavaAppPackaging)
+  .dependsOn(bootstrap % "test->test")
+
+lazy val test = project
+  .in(file("test"))
+  .settings(
+    name := "test"
+  )
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    inThisBuild(List(
+      organization := "com.github.huntc",
+      scalaVersion := "2.12.3",
+      version      := "0.1.0-SNAPSHOT",
+      ScalariformKeys.preferences := ScalariformKeys.preferences.value
+        .setPreference(AlignSingleLineCaseStatements, true)
+        .setPreference(DoubleIndentConstructorArguments, true)
+        .setPreference(DanglingCloseParenthesis, Preserve)
+    ))
+  )
+ .aggregate(bootstrap, daemon, test)

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -54,7 +54,7 @@ lazy val daemon = project
       val targetDir = (resourceManaged in Test).value
       val testClassesMappings = {
         val sourceDir = (classDirectory in Compile in test).value
-        (PathFinder(sourceDir).***).pair(Path.rebase(sourceDir, targetDir))
+        (PathFinder(sourceDir).allPaths).pair(Path.rebase(sourceDir, targetDir))
       }
       val bootstrapAssemblyMappings = {
         val sourceAssembly = (assembly in bootstrap).value

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -26,7 +26,9 @@ lazy val daemon = project
     name := "daemon",
     libraryDependencies ++= Seq(
       akkaContribExtra,
+      akkSlf4j,
       commonsCompress,
+      logbackClassic,
       scopt,
       akkaTestKit % Test,
       scalaTest % Test

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -11,6 +11,9 @@ lazy val bootstrap = project
       jna,
       scalaTest % Test
     ),
+    compileOrder in Compile := CompileOrder.JavaThenScala,
+    compileOrder in Test := CompileOrder.Mixed,
+    unmanagedSourceDirectories in Compile := (javaSource in Compile).value :: Nil,
     crossPaths := false,
     autoScalaLibrary := false
   )
@@ -29,9 +32,6 @@ lazy val daemon = project
       scalaTest % Test
     ),
     resolvers += Resolvers.typesafeBintrayReleases,
-    compileOrder in Compile := CompileOrder.JavaThenScala,
-    compileOrder in Test := CompileOrder.Mixed,
-    unmanagedSourceDirectories in Compile := (javaSource in Compile).value :: Nil,
     scriptClasspathOrdering := {
       val assemblyFile = assembly.value
       Seq(assemblyFile -> ("lib/" + assemblyFile.getName))

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -67,6 +67,7 @@ lazy val daemon = project
     // Native packager
     bashScriptExtraDefines += s"""addJava "-Dlandlordd.bootstrap-lib.path=$${app_home}/../$bootstrapLibPath"""",
     executableScriptName := "landlordd",
+    javaOptions in Universal ++= Seq("-J-Xms8m", "-J-Xmx8m", "-J-Xss256k"),
     mappings in Universal += {
       val bootstrapAssembly = (assembly in bootstrap).value
       bootstrapAssembly -> bootstrapLibPath

--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -2,7 +2,6 @@
 ( \
   echo "-cp classes example.Hello" && \
   tar -c -C $(pwd)/test/target/scala-2.12 classes &&
-  while read x ; do echo $x ; done && \
+  cat <&0 && \
   printf '\04' \
-  ) | nc 127.0.0.1 9000 &
-wait
+  ) | nc 127.0.0.1 9000

--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ( \
   echo "-cp classes example.Hello" && \
-  tar -c -C test/target/scala-2.12 classes &&
+  tar -c -C $(pwd)/test/target/scala-2.12 classes &&
   while read x ; do echo $x ; done && \
   printf '\04' \
   ) | nc 127.0.0.1 9000 &

--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
-trap 'cat <<< "hi"' SIGTERM SIGINT
 ( \
   echo "-cp classes example.Hello" && \
-  tar -c -C /Users/huntc/Projects/farmco/landlord/landlordd/test/target/scala-2.12 classes &&
+  tar -c -C test/target/scala-2.12 classes &&
   while read x ; do echo $x ; done && \
   printf '\04' \
   ) | nc 127.0.0.1 9000 &

--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+trap 'cat <<< "hi"' SIGTERM SIGINT
+( \
+  echo "-cp classes example.Hello" && \
+  tar -c -C /Users/huntc/Projects/farmco/landlord/landlordd/test/target/scala-2.12 classes &&
+  while read x ; do echo $x ; done && \
+  printf '\04' \
+  ) | nc 127.0.0.1 9000 &
+wait

--- a/landlordd/daemon/src/main/resources/application.conf
+++ b/landlordd/daemon/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+akka {
+  log-dead-letters-during-shutdown = off
+
+  loggers                          = [akka.event.slf4j.Slf4jLogger]
+  logging-filter                   = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel                         = info
+}

--- a/landlordd/daemon/src/main/resources/logback.xml
+++ b/landlordd/daemon/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${log-file:-logs/landlordd.log}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${log-file-archive:-logs/landlordd-%d{yyyy-MM-dd}.%i.log.gz}</fileNamePattern>
+            <maxFileSize>3MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>60MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} ${HOSTNAME} %-5level %logger{0} [%mdc] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.github.huntc" level="debug" additivity="false">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </logger>
+
+    <root level="${root.loglevel:-info}">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -1,0 +1,336 @@
+package com.github.huntc.landlord
+
+import akka.NotUsed
+import akka.actor.{ Actor, PoisonPill, Props }
+import akka.contrib.process.NonBlockingProcess
+import akka.pattern.pipe
+import akka.util.ByteString
+import akka.stream.{ ActorMaterializer, AbruptStageTerminationException, Attributes, FlowShape, Inlet, Outlet, OverflowStrategy, QueueOfferResult }
+import akka.stream.stage.{ AsyncCallback, GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.scaladsl.{ Keep, Sink, Source, SourceQueueWithComplete }
+import java.nio.ByteOrder
+import java.nio.file.{ Path, Paths }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+import scala.util.Success
+
+object JvmExecutor {
+  def props(in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]], bootstrapLibPath: Path, processDirPath: Path): Props =
+    Props(new JvmExecutor(in, out, bootstrapLibPath, processDirPath))
+
+  case class StartProcess(commandLine: String, stdin: Source[ByteString, AnyRef])
+  case class StopProcess(signal: Int)
+
+  private[landlord] sealed abstract class ProcessInputPart
+  private[landlord] case class CommandLine(value: String) extends ProcessInputPart
+  private[landlord] case class Archive(value: Source[ByteString, AnyRef]) extends ProcessInputPart
+  private[landlord] case class Stdin(value: Source[ByteString, AnyRef]) extends ProcessInputPart
+  private[landlord] case class Signal(value: Int) extends ProcessInputPart
+
+  private[landlord] class ProcessParameterParser(implicit mat: ActorMaterializer, ec: ExecutionContext)
+    extends GraphStage[FlowShape[ByteString, ProcessInputPart]] {
+
+    val in = Inlet[ByteString]("ProcessParameters.in")
+    val out = Outlet[ProcessInputPart]("ProcessParameters.out")
+
+    override val shape = FlowShape.of(in, out)
+
+    override def createLogic(attr: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) {
+
+        val asyncTryPull = getAsyncCallback[Unit](_ => if (!hasBeenPulled(in)) tryPull(in))
+        val asyncCancel = getAsyncCallback[Unit](_ => cancel(in))
+
+        def receiveCommandLine(commandLine: StringBuilder)(bytes: ByteString): ByteString = {
+          val posn = bytes.indexOf('\n')
+          val (left, right) = bytes.splitAt(posn)
+          if (left.isEmpty) {
+            commandLine ++= right.utf8String
+            pull(in)
+            ByteString.empty
+          } else {
+            commandLine ++= left.utf8String
+            emit(out, CommandLine(commandLine.toString))
+            becomeReceiveTar()
+            right.drop(1)
+          }
+        }
+
+        def becomeReceiveTar(): Unit = {
+          val (queue, ar) =
+            Source
+              .queue[ByteString](100, OverflowStrategy.backpressure)
+              .prefixAndTail(0)
+              .map {
+                case (_, in) => in
+              }
+              .toMat(Sink.head)(Keep.both)
+              .run
+          emit(out, Archive(Source.fromFutureSource(ar)))
+          become(receiveTar(asyncTryPull, asyncCancel, queue, ByteString.empty))
+        }
+
+        def receiveTar(
+          asyncTryPull: AsyncCallback[Unit], asyncCancel: AsyncCallback[Unit],
+          queue: SourceQueueWithComplete[ByteString], recordBuffer: ByteString)(bytes: ByteString): ByteString = {
+          val Blocksize = 512
+          val Eotsize = Blocksize * 2
+          val BlockingFactor = 20
+          val RecordSize = Blocksize * BlockingFactor
+          val remaining = RecordSize - recordBuffer.size
+          val (add, carry) = bytes.splitAt(remaining)
+          val enqueueRecordBuffer = recordBuffer ++ add
+          val nonEnqueuedRecordBuffer =
+            if (enqueueRecordBuffer.size == RecordSize) {
+              queue.offer(enqueueRecordBuffer).andThen {
+                case Success(QueueOfferResult.Enqueued) => asyncTryPull.invoke(())
+                case _                                  => asyncCancel.invoke(())
+              }
+              ByteString.empty
+            } else if (carry.isEmpty && !hasBeenPulled(in)) {
+              tryPull(in)
+              enqueueRecordBuffer
+            } else {
+              enqueueRecordBuffer
+            }
+          if (enqueueRecordBuffer.takeRight(Eotsize).forall(_ == 0)) {
+            queue.complete()
+            becomeReceiveStdin()
+          } else {
+            become(receiveTar(asyncTryPull, asyncCancel, queue, nonEnqueuedRecordBuffer))
+          }
+          carry
+        }
+
+        def becomeReceiveStdin(): Unit = {
+          val (queue, stdin) =
+            Source
+              .queue[ByteString](100, OverflowStrategy.backpressure)
+              .prefixAndTail(0)
+              .map {
+                case (_, in) => in
+              }
+              .toMat(Sink.head)(Keep.both)
+              .run
+          emit(out, Stdin(Source.fromFutureSource(stdin)))
+          become(receiveStdin(asyncTryPull, asyncCancel, queue))
+        }
+
+        def receiveStdin(
+          asyncTryPull: AsyncCallback[Unit], asyncCancel: AsyncCallback[Unit],
+          queue: SourceQueueWithComplete[ByteString])(bytes: ByteString): ByteString = {
+          val eotPosn = bytes.indexOf(4)
+          val (left, right) = if (eotPosn == -1) bytes -> ByteString.empty else bytes.splitAt(eotPosn)
+          queue.offer(left).andThen {
+            case Success(QueueOfferResult.Enqueued) => asyncTryPull.invoke(())
+            case _                                  => asyncCancel.invoke(())
+          }
+          if (eotPosn > -1) {
+            queue.complete()
+            become(receiveSignal(ByteString.empty))
+          } else {
+            become(receiveStdin(asyncTryPull, asyncCancel, queue))
+          }
+          right.drop(1)
+        }
+
+        def receiveSignal(recordBuffer: ByteString)(bytes: ByteString): ByteString = {
+          val RecordSize = 4
+          val remaining = RecordSize - recordBuffer.size
+          val (add, carry) = bytes.splitAt(remaining)
+          val newRecordBuffer = recordBuffer ++ add
+          if (newRecordBuffer.size == RecordSize) {
+            emit(out, Signal(newRecordBuffer.iterator.getInt(ByteOrder.BIG_ENDIAN)))
+            become(receiveFinished())
+          } else {
+            become(receiveSignal(newRecordBuffer))
+          }
+          if (carry.isEmpty) pull(in)
+          carry
+        }
+
+        def receiveFinished()(bytes: ByteString): ByteString =
+          receive(ByteString.empty)
+
+        def become(receiver: ByteString => ByteString): Unit =
+          receive = receiver
+        var receive: ByteString => ByteString = receiveCommandLine(new StringBuilder)
+
+        setHandler(in, new InHandler {
+          override def onPush(): Unit = {
+            @tailrec def doReceive(bytes: ByteString): ByteString =
+              if (bytes.nonEmpty) doReceive(receive(bytes)) else bytes
+            doReceive(grab(in))
+          }
+        })
+
+        setHandler(out, new OutHandler {
+          override def onPull(): Unit = {
+            if (!hasBeenPulled(in)) pull(in)
+          }
+        })
+      }
+  }
+
+  private[landlord] case class JavaConfig(
+      cp: String = "",
+      mainClass: String = ""
+  )
+
+  private[landlord] val parser = new scopt.OptionParser[JavaConfig](Version.executableScriptName) {
+    opt[String]("classpath").abbr("cp").action { (x, c) =>
+      c.copy(cp = x)
+    }
+
+    arg[String]("main class").action { (x, c) =>
+      c.copy(mainClass = x)
+    }
+  }
+
+  private[landlord] case class ExitEarly(exitStatus: Int, errorMessage: Option[String])
+
+  private[landlord] val SIGINT = 2
+  private[landlord] val SIGKILL = 9
+  private[landlord] val SIGTERM = 15
+
+  private[landlord] def sizeToBytes(size: Int): ByteString =
+    ByteString.newBuilder.putInt(size)(ByteOrder.BIG_ENDIAN).result()
+
+  private[landlord] def exitStatusToBytes(statusCode: Int): ByteString =
+    ByteString.newBuilder.putByte('x').putInt(statusCode)(ByteOrder.BIG_ENDIAN).result()
+
+  private[landlord] val StdoutPrefix = ByteString('o'.toByte)
+  private[landlord] val StderrPrefix = ByteString('e'.toByte)
+}
+
+/**
+ * A JVM Executor creates a JVM process and is also responsible for terminating it.
+ *
+ * The executor is constructed with a stream through which `java` command line args are
+ * received along with a tar filesystem to read from followed by stdin and a signal. An outward
+ * stream is also provided for transmitting stdout, stderr and the process's final exit code.
+ *
+ * The following specifications assume big-endian byte order.
+ *
+ * The incoming stream is presented as follows:
+ *
+ * 1. The first line (up until a LF) are the command line args to pass to the `java` command.
+ *    The arguments are decoded as UTF-8.
+ * 2. The next line represents the binary tar file output of the file system that the `java`
+ *    command and its host program will ultimately read from e.g. containing the class files.
+ * 3. The stream then represents stdin until an EOT is received. The input is decoded as UTF-8.
+ * 4. The remaining stream will consist of a four byte integer representing a signal code
+ *    and which will also terminate the stream.
+ *
+ * The outgoing stream is presented as follows:
+ *
+ * 1. A single UTF-8 character representing one of 'o', 'e' or 'x' (stdout, stderr, exit code).
+ *
+ * In the case of 'o' or 'e' then there is a four byte integer providing the length of the
+ * UTF-8 characters to follow.
+ *
+ * Exit codes are conveyed as a four byte integer and are followed by the stream being
+ * terminated. All stdout and stderr is guaranteed to be sent prior to the exit code being
+ * transmitted.
+ */
+class JvmExecutor(in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]], bootstrapLibPath: Path, processDirPath: Path) extends Actor {
+
+  import JvmExecutor._
+
+  implicit val mat = ActorMaterializer()
+  import context.dispatcher
+
+  def stopSelfWhenDone(mat: NotUsed, done: Future[akka.Done]): NotUsed = {
+    done.map(_ => PoisonPill).pipeTo(self)
+    NotUsed
+  }
+
+  override def preStart: Unit =
+    in
+      .via(new ProcessParameterParser)
+      .runFoldAsync("") {
+        case (_, CommandLine(value)) =>
+          Future.successful(value)
+        case (cl, Archive(value)) =>
+          TarStreamWriter
+            .writeTarStream(
+              value,
+              processDirPath,
+              context.system.dispatchers.lookup("akka.actor.default-blocking-io-dispatcher")
+            )
+            .map(_ => cl)
+        case (cl, Stdin(value)) =>
+          self ! StartProcess(cl, value)
+          Future.successful(cl)
+        case (cl, Signal(value)) =>
+          self ! StopProcess(value)
+          Future.successful(cl)
+      }
+      .recover {
+        case e: AbruptStageTerminationException =>
+          // Swallow it up - it is quite normal that our process exits with this stream
+          // still active
+          throw e
+        case NonFatal(e) =>
+          self ! ExitEarly(1, Some(e.getMessage))
+          throw e
+      }
+
+  def receive: Receive =
+    starting
+
+  def starting: Receive = {
+    case StartProcess(commandLine, stdinSource) =>
+      val javaCommand = Paths.get(sys.props.get("java.home").getOrElse("/usr") + "/bin/java").toString
+      parser.parse(commandLine.split(" "), JavaConfig()) match {
+        case Some(javaConfig) =>
+          val args =
+            List(
+              javaCommand,
+              "-cp", bootstrapLibPath.toAbsolutePath.toString + (if (javaConfig.cp.nonEmpty) ":" + javaConfig.cp else ""),
+              "com.github.huntc.landlord.Main", // Launch via our bootstrap class so that we get a look-in to do stuff.
+              javaConfig.mainClass
+            )
+          context.actorOf(NonBlockingProcess.props(args, workingDir = processDirPath.toAbsolutePath))
+          context.become(started(stdinSource, Promise[Int]()))
+        case None =>
+          self ! ExitEarly(1, Some("Command line error: " + commandLine))
+      }
+
+    case _: StopProcess =>
+      self ! ExitEarly(128 + SIGINT, None)
+
+    case ExitEarly(exitStatus, errorMessage) =>
+      out.success(
+        Source
+          .single {
+            errorMessage.fold(ByteString.empty)(e => StderrPrefix ++ ByteString(e)) ++
+              exitStatusToBytes(exitStatus)
+          }
+          .watchTermination()(stopSelfWhenDone)
+      )
+  }
+
+  def started(stdinSource: Source[ByteString, AnyRef], exitStatusPromise: Promise[Int]): Receive = {
+    case NonBlockingProcess.Started(pid, stdin, stdout, stderr) =>
+      stdinSource.runWith(stdin)
+      out.success(
+        stdout
+          .map(bytes => StdoutPrefix ++ sizeToBytes(bytes.size) ++ bytes)
+          .merge(stderr.map(bytes => StderrPrefix ++ sizeToBytes(bytes.size) ++ bytes))
+          .concat(Source.fromFuture(exitStatusPromise.future.map(exitStatusToBytes)))
+          .watchTermination()(stopSelfWhenDone))
+
+    case StopProcess(signal) =>
+      val process = context.children.headOption
+      signal match {
+        case SIGTERM => process.foreach(_ ! NonBlockingProcess.Destroy)
+        case SIGKILL => process.foreach(_ ! NonBlockingProcess.DestroyForcibly)
+        case other   => sys.error(s"Unsupported signal: $other. Ignoring.")
+      }
+
+    case NonBlockingProcess.Exited(status) =>
+      exitStatusPromise.success(status)
+  }
+}

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -1,0 +1,71 @@
+package com.github.huntc.landlord
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ Flow, Source, Tcp }
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+import java.nio.file.{ Files, Path, Paths }
+import scala.concurrent.duration._
+import scala.concurrent.Promise
+
+object Main extends App {
+  case class Config(
+      bindIp: String = "127.0.0.1",
+      bindPort: Int = 9000,
+      bootstrapLibPath: Path = Paths.get(sys.props.getOrElse("landlordd.bootstrap-lib.path", "")),
+      processDirPath: Path = Files.createTempDirectory("jvm-executor"))
+
+  val parser = new scopt.OptionParser[Config](Version.executableScriptName) {
+    head(Version.executableScriptName, Version.current)
+    note("Daemon for sharing JVM memory between JVM processes - used with a client as a substitute for the `java` command")
+
+    opt[String]("bind-ip").action { (x, c) =>
+      c.copy(bindIp = x)
+    }.text("The IP address to listen on.")
+
+    opt[Int]("bind-port").action { (x, c) =>
+      c.copy(bindPort = x)
+    }.text("The port to listen on")
+
+    opt[String]("bootstrap-lib-path").action { (x, c) =>
+      c.copy(bootstrapLibPath = Paths.get(x))
+    }.text("The path to bootstrap library used when forking Java processes.")
+
+    opt[String]("process-dir-path").action { (x, c) =>
+      c.copy(processDirPath = Paths.get(x))
+    }.text("The path to use for the working directory for the process.")
+  }
+
+  parser.parse(args, Config()) match {
+    case Some(config) =>
+      implicit val system = ActorSystem("landlordd")
+      implicit val mat = ActorMaterializer()
+
+      Tcp().bind(config.bindIp, config.bindPort).runForeach { connection =>
+        println(s"New connection from: ${connection.remoteAddress}")
+
+        val flow =
+          Flow[ByteString]
+            .prefixAndTail(0) // Lift our incoming stream into another Source that we can pass around
+            .map {
+              case (_, in) =>
+                val out = Promise[Source[ByteString, NotUsed]]()
+                system.actorOf(JvmExecutor.props(
+                  in,
+                  out,
+                  config.bootstrapLibPath,
+                  config.processDirPath.resolve(connection.remoteAddress.getPort.toString)
+                ))
+                Source.fromFutureSource(out.future)
+            }
+            .flatMapConcat(identity)
+
+        connection.handleWith(flow)
+      }
+      println("Ready.")
+
+    case None =>
+    // arguments are bad, error message will have been displayed
+  }
+}

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -43,7 +43,7 @@ object Main extends App {
       implicit val mat = ActorMaterializer()
 
       Tcp().bind(config.bindIp, config.bindPort).runForeach { connection =>
-        println(s"New connection from: ${connection.remoteAddress}")
+        system.log.info("New connection from {}", connection.remoteAddress)
 
         val flow =
           Flow[ByteString]
@@ -63,7 +63,7 @@ object Main extends App {
 
         connection.handleWith(flow)
       }
-      println("Ready.")
+      system.log.info("Ready.")
 
     case None =>
     // arguments are bad, error message will have been displayed

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/TarStreamWriter.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/TarStreamWriter.scala
@@ -1,0 +1,79 @@
+package com.github.huntc.landlord
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Source, StreamConverters }
+import akka.util.ByteString
+import java.io.{ BufferedInputStream, BufferedOutputStream }
+import java.nio.file.{ attribute, Files, Path }
+import org.apache.commons.compress.archivers.ArchiveStreamFactory
+import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveInputStream }
+import scala.concurrent.{ blocking, ExecutionContext, Future }
+import scala.concurrent.duration._
+import scala.annotation.tailrec
+
+/**
+ * Functions to write out tar streams
+ */
+object TarStreamWriter {
+  private[landlord] def writeTarStream(
+    source: Source[ByteString, AnyRef],
+    rootPath: Path,
+    blockingEc: ExecutionContext
+  )(implicit mat: Materializer): Future[Unit] = {
+
+    val BufferSize = 8192
+    val MaxBlockingTime = 3.seconds
+
+    Future {
+      val is = new BufferedInputStream(source.runWith(StreamConverters.asInputStream(MaxBlockingTime)))
+      try {
+        val tarInput = new ArchiveStreamFactory().createArchiveInputStream(is).asInstanceOf[TarArchiveInputStream]
+        try {
+          val buffer = Array.ofDim[Byte](BufferSize)
+          blocking {
+            @tailrec def foreachTarEntry(op: TarArchiveEntry => Unit): Unit =
+              tarInput.getNextTarEntry() match {
+                case null =>
+                  ()
+                case entry =>
+                  op(entry)
+                  foreachTarEntry(op)
+              }
+            foreachTarEntry { entry =>
+              val path = rootPath.resolve(entry.getName)
+              if (entry.isDirectory) {
+                path.toFile.mkdirs()
+              } else {
+                val os = new BufferedOutputStream(Files.newOutputStream(path))
+                try {
+                  @tailrec def foreachRead(offset: Int)(op: Array[Byte] => Unit): Unit = {
+                    val remaining = buffer.length - offset
+                    if (remaining > 0) {
+                      val read = tarInput.read(buffer, offset, remaining)
+                      if (read > -1)
+                        foreachRead(offset + read)(op)
+                      else
+                        op(buffer.take(offset))
+                    } else {
+                      op(buffer)
+                      foreachRead(0)(op)
+                    }
+                  }
+                  foreachRead(0)(os.write)
+                } finally {
+                  os.close()
+                }
+                Files.setLastModifiedTime(path, attribute.FileTime.fromMillis(entry.getModTime.getTime))
+                // TODO: Set ownership and permissions.
+              }
+            }
+          }
+        } finally {
+          tarInput.close()
+        }
+      } finally {
+        is.close()
+      }
+    }(blockingEc)
+  }
+}

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -4,14 +4,15 @@ import akka.util.{ ByteString, ByteStringBuilder }
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
-import akka.testkit.{ TestKit, TestProbe }
+import akka.testkit._
 import java.io.ByteArrayOutputStream
 import java.nio.ByteOrder
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{ Files, Paths }
 import org.apache.commons.compress.archivers.ArchiveStreamFactory
 import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveOutputStream }
 import org.scalatest._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration._
 
 class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
   with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
@@ -161,7 +162,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
 
       val watcher = TestProbe()
       watcher.watch(process)
-      watcher.expectTerminated(process)
+      watcher.expectTerminated(process, max = 5.seconds.dilated)
 
       outputOk
     }

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -138,7 +138,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
               .runFold(ByteString.empty)(_ ++ _)
               .map { bytes =>
                 val (_, _, _, byteStrings) = bytes.foldLeft((false, 0, 0, List.empty[ByteStringBuilder])) {
-                  case ((false, 0, 0, byteStrings), byte) if byte == 'o'.toByte =>
+                  case ((false, 0, 0, byteStrings), byte) if byte == 'o'.toByte || byte == 'e'.toByte =>
                     (true, 0, 0, byteStrings)
                   case ((false, 0, 0, byteStrings), byte) if byte == 'x'.toByte =>
                     (false, 0, 4, byteStrings :+ ByteString.newBuilder)
@@ -154,9 +154,9 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
                     byteStrings.last.putByte(byte)
                     (false, 0, size - 1, byteStrings)
                 }
-                val stdoutBytes = byteStrings.dropRight(1).foldLeft(ByteString.empty)(_ ++ _.result)
+                val outputBytes = byteStrings.dropRight(1).foldLeft(ByteString.empty)(_ ++ _.result)
                 val exitCodeBytes = byteStrings.last.result
-                assert(stdoutBytes.utf8String == stdin && exitCodeBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == 0)
+                assert(outputBytes.utf8String == stdin && exitCodeBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == 0)
               }
           }(ExecutionContext.Implicits.global) // We use this context to get us off the ScalaTest one (which would hang this)
 

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -1,0 +1,169 @@
+package com.github.huntc.landlord
+
+import akka.util.{ ByteString, ByteStringBuilder }
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.testkit.{ TestKit, TestProbe }
+import java.io.ByteArrayOutputStream
+import java.nio.ByteOrder
+import java.nio.file.{ Files, Path, Paths }
+import org.apache.commons.compress.archivers.ArchiveStreamFactory
+import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveOutputStream }
+import org.scalatest._
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+
+class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
+  with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val mat = ActorMaterializer()
+
+  "The ProcessParameterParser" should {
+    "produce a flow of ProcessInputParts in the required order given a valid input" in {
+      val cl = "some args"
+
+      val tar = {
+        val bos = new ByteArrayOutputStream()
+        val tos =
+          new ArchiveStreamFactory()
+            .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)
+            .asInstanceOf[TarArchiveOutputStream]
+        try {
+          tos.flush()
+          tos.finish()
+        } finally {
+          tos.close()
+        }
+        bos.toByteArray
+      }
+
+      val stdin = "some stdin\nsome more stdin\n"
+
+      val signal = 15
+
+      val TarRecordSize = 10240
+
+      Source
+        .single(
+          ByteString(cl + "\n") ++
+            ByteString(tar) ++
+            ByteString(stdin + "\u0004") ++
+            ByteString.newBuilder.putInt(signal)(ByteOrder.BIG_ENDIAN).result()
+        )
+        .via(new JvmExecutor.ProcessParameterParser)
+        .runFoldAsync(0 -> assert(true)) {
+          case ((ordinal, _), JvmExecutor.CommandLine(value)) =>
+            Future.successful(1 -> assert(ordinal == 0 && value == cl))
+          case ((ordinal, _), JvmExecutor.Archive(value)) =>
+            val complete = value.runFold(0L)(_ + _.size)
+            complete.map(tarSize => 2 -> assert(ordinal == 1 && tarSize == TarRecordSize))
+          case ((ordinal, _), JvmExecutor.Stdin(value)) =>
+            val complete = value.runFold("")(_ ++ _.utf8String)
+            complete.map(input => 3 -> assert(ordinal == 2 && input == stdin))
+          case ((ordinal, _), JvmExecutor.Signal(value)) =>
+            Future.successful(4 -> assert(ordinal == 3 && value == signal))
+        }
+        .map {
+          case (count, Succeeded) if count == 4 => Succeeded
+          case (count, Succeeded)               => assert(count == 4)
+          case (_, lastAssertion)               => lastAssertion
+        }
+    }
+  }
+
+  "The JVMExecutor" should {
+    "start a process that then outputs stdin, ends and shuts everything down" in {
+      val cl = "-cp classes example.Hello"
+
+      val tar = {
+        val bos = new ByteArrayOutputStream()
+        val tos =
+          new ArchiveStreamFactory()
+            .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)
+            .asInstanceOf[TarArchiveOutputStream]
+        try {
+          {
+            val te = new TarArchiveEntry("classes/")
+            tos.putArchiveEntry(te)
+            tos.closeArchiveEntry()
+          }
+          {
+            val te = new TarArchiveEntry("classes/example/")
+            tos.putArchiveEntry(te)
+            tos.closeArchiveEntry()
+          }
+          {
+            val te = new TarArchiveEntry("classes/example/Hello.class")
+            val classFile = Paths.get(getClass.getResource("/example/Hello.class").toURI)
+            val data = Files.readAllBytes(classFile)
+            te.setSize(data.length.toLong)
+            tos.putArchiveEntry(te)
+            tos.write(data)
+            tos.closeArchiveEntry()
+          }
+          tos.flush()
+          tos.finish()
+        } finally {
+          tos.close()
+        }
+        bos.toByteArray
+      }
+
+      val stdin = "Hello World\n"
+
+      val in =
+        Source
+          .single(
+            ByteString(cl + "\n") ++
+              ByteString(tar) ++
+              ByteString(stdin + "\u0004")
+          )
+
+      val out = Promise[Source[ByteString, akka.NotUsed]]()
+      val bootstrapLibPath = Paths.get(getClass.getResource("/bootstrap-assembly.jar").toURI)
+      val processDirPath = Files.createTempDirectory("jvm-executor-spec")
+      processDirPath.toFile.deleteOnExit
+
+      val process = system.actorOf(JvmExecutor.props(in, out, bootstrapLibPath, processDirPath))
+
+      val outputOk =
+        out.future
+          .flatMap { outSource =>
+            outSource
+              .runFold(ByteString.empty)(_ ++ _)
+              .map { bytes =>
+                val (_, _, _, byteStrings) = bytes.foldLeft((false, 0, 0, List.empty[ByteStringBuilder])) {
+                  case ((false, 0, 0, byteStrings), byte) if byte == 'o'.toByte =>
+                    (true, 0, 0, byteStrings)
+                  case ((false, 0, 0, byteStrings), byte) if byte == 'x'.toByte =>
+                    (false, 0, 4, byteStrings :+ ByteString.newBuilder)
+                  case ((true, 0, 0, byteStrings), byte) =>
+                    (true, 1, byte << 24, byteStrings)
+                  case ((true, 1, size, byteStrings), byte) =>
+                    (true, 2, size | (byte << 16), byteStrings)
+                  case ((true, 2, size, byteStrings), byte) =>
+                    (true, 3, size | (byte << 8), byteStrings)
+                  case ((true, 3, size, byteStrings), byte) =>
+                    (false, 0, size | byte, byteStrings :+ ByteString.newBuilder)
+                  case ((false, 0, size, byteStrings), byte) if size > 0 =>
+                    byteStrings.last.putByte(byte)
+                    (false, 0, size - 1, byteStrings)
+                }
+                val stdoutBytes = byteStrings.dropRight(1).foldLeft(ByteString.empty)(_ ++ _.result)
+                val exitCodeBytes = byteStrings.last.result
+                assert(stdoutBytes.utf8String == stdin && exitCodeBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == 0)
+              }
+          }(ExecutionContext.Implicits.global) // We use this context to get us off the ScalaTest one (which would hang this)
+
+      val watcher = TestProbe()
+      watcher.watch(process)
+      watcher.expectTerminated(process)
+
+      outputOk
+    }
+  }
+}

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/TarStreamWriterSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/TarStreamWriterSpec.scala
@@ -1,0 +1,72 @@
+package com.github.huntc.landlord
+
+import akka.util.ByteString
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.testkit.TestKit
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import org.apache.commons.compress.archivers.{ ArchiveException, ArchiveStreamFactory }
+import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveOutputStream }
+import org.scalatest._
+
+class TarStreamWriterSpec extends TestKit(ActorSystem("TarStreamWriterSpec"))
+  with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  "The TarStreamWriter" should {
+    "Write out a valid stream of Tar input" in {
+      implicit val mat = ActorMaterializer()
+      val rootPath = Files.createTempDirectory("TarStreamWriterSpec")
+      rootPath.toFile.deleteOnExit()
+      val source =
+        Source.single {
+          val bos = new ByteArrayOutputStream()
+          val tos =
+            new ArchiveStreamFactory()
+              .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)
+              .asInstanceOf[TarArchiveOutputStream]
+          try {
+            {
+              val te = new TarArchiveEntry("dir/")
+              tos.putArchiveEntry(te)
+              tos.closeArchiveEntry()
+            }
+            {
+              val te = new TarArchiveEntry("dir/foo")
+              val data = "some-content".getBytes("UTF-8")
+              te.setSize(data.length.toLong)
+              tos.putArchiveEntry(te)
+              tos.write(data)
+              tos.closeArchiveEntry()
+            }
+            tos.flush()
+            tos.finish()
+          } finally {
+            tos.close()
+          }
+          ByteString(bos.toByteArray)
+        }
+      val blockingEc = scala.concurrent.ExecutionContext.Implicits.global
+      TarStreamWriter.writeTarStream(source, rootPath, blockingEc).map { _ =>
+        val file = rootPath.resolve("dir/foo")
+        assert(Files.size(file) == 12)
+      }
+    }
+
+    "Reject an invalid stream of Tar input by failing the future" in {
+      implicit val mat = ActorMaterializer()
+      val rootPath = Files.createTempDirectory("TarStreamWriterSpec")
+      rootPath.toFile.deleteOnExit()
+      val source = Source.single(ByteString.empty)
+      val blockingEc = scala.concurrent.ExecutionContext.Implicits.global
+      recoverToSucceededIf[ArchiveException] {
+        TarStreamWriter.writeTarStream(source, rootPath, blockingEc)
+      }
+    }
+  }
+}

--- a/landlordd/project/Dependencies.scala
+++ b/landlordd/project/Dependencies.scala
@@ -1,0 +1,18 @@
+import sbt._
+import sbt.Resolver.bintrayRepo
+
+object Dependencies {
+  lazy val akkaContribExtra = ("com.typesafe.akka" %% "akka-contrib-extra" % "4.1.3")
+    .exclude("com.typesafe.akka", "akka-cluster")
+    .exclude("com.typesafe.akka", "akka-distributed-data")
+    .exclude("com.typesafe.akka", "akka-http") // FIXME: The excludes aren't working for some reason
+  lazy val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % "2.5.6"
+  lazy val commonsCompress = "org.apache.commons" % "commons-compress" % "1.14"
+  lazy val jna = "net.java.dev.jna" % "jna" % "4.5.0"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.3"
+  lazy val scopt = "com.github.scopt" %% "scopt" % "3.7.0"
+}
+
+object Resolvers {
+  lazy val typesafeBintrayReleases = bintrayRepo("typesafe", "maven-releases")
+}

--- a/landlordd/project/Dependencies.scala
+++ b/landlordd/project/Dependencies.scala
@@ -1,16 +1,28 @@
 import sbt._
 import sbt.Resolver.bintrayRepo
 
+object Versions {
+  lazy val akka = "2.5.6"
+  lazy val akkaContribExtra = "4.1.3"
+  lazy val commonsCompress = "1.14"
+  lazy val logbackClassic = "1.2.3"
+  lazy val jna = "4.5.0"
+  lazy val scalaTest = "3.0.3"
+  lazy val scopt = "3.7.0"
+}
+
 object Dependencies {
-  lazy val akkaContribExtra = ("com.typesafe.akka" %% "akka-contrib-extra" % "4.1.3")
+  lazy val akkaContribExtra = ("com.typesafe.akka" %% "akka-contrib-extra" % Versions.akkaContribExtra)
     .exclude("com.typesafe.akka", "akka-cluster")
     .exclude("com.typesafe.akka", "akka-distributed-data")
     .exclude("com.typesafe.akka", "akka-http") // FIXME: The excludes aren't working for some reason
-  lazy val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % "2.5.6"
-  lazy val commonsCompress = "org.apache.commons" % "commons-compress" % "1.14"
-  lazy val jna = "net.java.dev.jna" % "jna" % "4.5.0"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.3"
-  lazy val scopt = "com.github.scopt" %% "scopt" % "3.7.0"
+  lazy val akkSlf4j = "com.typesafe.akka" %% "akka-slf4j" % Versions.akka
+  lazy val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % Versions.akka
+  lazy val commonsCompress = "org.apache.commons" % "commons-compress" % Versions.commonsCompress
+  lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % Versions.logbackClassic
+  lazy val jna = "net.java.dev.jna" % "jna" % Versions.jna
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest
+  lazy val scopt = "com.github.scopt" %% "scopt" % Versions.scopt
 }
 
 object Resolvers {

--- a/landlordd/project/build.properties
+++ b/landlordd/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.2

--- a/landlordd/project/build.properties
+++ b/landlordd/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/landlordd/project/plugins.sbt
+++ b/landlordd/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -1,0 +1,12 @@
+package example;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public class Hello {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        System.out.println(br.readLine());
+    }
+}


### PR DESCRIPTION
This initial PR demonstrates that JVM based programs can be launched via `landlordd` and that resident memory can be saved in doing so i.e. landlord's main goal.

To illustrate:

1. Build the daemon:

```
cd landlord/landlordd/
sbt daemon/stage
```

2. Run it (`/tmp/a` is simply where forked processes will run within):

```
daemon/target/universal/stage/bin/landlordd --process-dir-path=/tmp/a
```

You should see `Ready.` output when the daemon is ready to receive requests.

3. From another terminal, launch a bash script that will connect to it, along with invoking a sample HelloWorld we have:

```
cd landlord/landlordd/
./client.sh
```

You should then see a connection message output by the daemon. Something like:

```
New connection from: /127.0.0.1:63292
```

4. Type some stdin in the bash script window. Having done so, the sample hello world program we have should echo the stdin. Something like this:

```
Christophers-MacBook-Pro-2:landlordd huntc$ ./client.sh
Hi there
o	Hi there
x
```

`Hi there` is what I typed in. The `o` and `Hi there` is the stdout and the `x` is the exit code. We're not seeing some values such as the string length and actual exit code because the `bash echo` command is not outputting them (we'll write a more sophisticated native client down the track).

5. The bash script expects you to just hit `return` to end sending stdin.

***

To see how much resident memory is being consumed, run `/usr/bin/time` with `-l`:

```
 /usr/bin/time -l daemon/target/universal/stage/bin/landlordd --process-dir-path=/tmp/a
```

Repeat the above steps and then CtrlC when done. You should see something like:

```
 229584896  maximum resident set size
```

...in the output. This is the cost of running landlordd and any subprocess. I've observed that around 10MiB additional memory is required to run the hello world app, compared to approximately 35MiB without landlord. That’s also considering any extra mem landlord requires to fork the process etc. We need a better way to measure the sub processes usage of resident memory as I suspect hello world to be closer to just 1MiB. I'd also imagine further gains with more class libraries being shared (I suspect that class files are memory mapped and thus candidates for sharing).

There's plenty left to do, in particular securing the forked process's world using a security manager, cgroups etc. Then there's the native client...

Meanwhile, there's reasonable test coverage for the existing code so I think that this is a reasonable first cut.

### UPDATE

So, @longshorej, I'm no longer sure that process forking gains us that much after all. :-)

I've been using `pmap` in order to determine the amount of [`pss`](https://en.wikipedia.org/wiki/Proportional_set_size) and notice that my hello-world app has a similar `pss` when running via Landlord as it does when running standalone. Here's the result of for hello-world when running directly from `java`:

```
$ pmap -X 8014
8014:   /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -cp /home/huntc/landlord/landlordd/daemon/target/universal/stage/bin/../extra/bootstrap.jar:classes com.github.huntc.landlord.Main example.Hello
         Address Perm   Offset Device  Inode    Size   Rss   Pss Referenced Anonymous Shared_Hugetlb Private_Hugetlb Swap SwapPss Locked Mapping
...
                                             ======= ===== ===== ========== ========= ============== =============== ==== ======= ====== 
                                             2763144 37532 35145      37532     20460              0               0    0       0      0 KB 
```

...and then I run another one:

```
8183:   /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -cp /home/huntc/landlord/landlordd/daemon/target/universal/stage/bin/../extra/bootstrap.jar:classes com.github.huntc.landlord.Main example.Hello
         Address Perm   Offset Device  Inode    Size   Rss   Pss Referenced Anonymous Shared_Hugetlb Private_Hugetlb Swap SwapPss Locked Mapping
                                             ======= ===== ===== ========== ========= ============== =============== ==== ======= ====== 
                                             2763144 37460 27944      37460     20432              0               0    0       0      0 KB 
```

...see that my `pss` has gone down about 7MiB (the formula for pss == unshareable + (sharable / numProcesses). Thus, there was about 14MiB of stuff to be shared for the program (about 40%).

When the process is invoked via `landlordd`:

```
8111:   /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -cp /home/huntc/landlord/landlordd/daemon/target/universal/stage/bin/../extra/bootstrap.jar:classes com.github.huntc.landlord.Main example.Hello
         Address Perm   Offset Device  Inode    Size   Rss   Pss Referenced Anonymous Shared_Hugetlb Private_Hugetlb Swap SwapPss Locked Mapping
...
                                             ======= ===== ===== ========== ========= ============== =============== ==== ======= ====== 
                                             2763144 37524 28075      37524     20564              0               0    0       0      0 KB 
```

...we're saving about 10MiB, but also at the cost of running `landlordd` itself, which I've clocked at a `pss` of 143MiB with the forked process running and with `-J-Xms8m -J-Xmx8m -J-Xss256k` as its options i.e. I don't reckon I can get that much smaller other than perhaps using a 32bit JVM.

I believe that I'm observing the fact that most of what the JVM brings in are shared objects e.g.: `libjvm.so`, `sunjce_provider.jar` and so on...

The question then becomes, how can we ever recover the overhead of running `landlordd` itself? I don't see that we can... wdyt? Back to my original thinking on going the OSGi/nailgun style of approach i.e. the single JVM instance with dynamic class loading?

### ANOTHER UPDATE
#### IBM's OpenJ9
I also tried IBM's OpenJ9 JVM with class sharing enabled. Firstly, the `res` and `pss` was actually larger than with OpenJDK's Hotspot! This is contrary to my understanding that OpenJ9 should yield greater memory efficiencies. Secondly, class sharing yields neglible benefits. Here are the class cache stats:

```
$ jdk-9+181/bin/java -Xshareclasses:printStats

Current statistics for cache "sharedcc_huntc": 

Cache created with:
	-Xnolinenumbers                      = false
	BCI Enabled                          = true
	Restrict Classpaths                  = false
	Feature                              = cr

Cache contains only classes with line numbers

base address                         = 0x00007F4E7D915000
end address                          = 0x00007F4E7E8F9000
allocation pointer                   = 0x00007F4E7DBDBB08

cache size                           = 16776608
softmx bytes                         = 16776608
free bytes                           = 12364652
ROMClass bytes                       = 2910984
AOT bytes                            = 2424
Reserved space for AOT bytes         = -1
Maximum space for AOT bytes          = -1
JIT data bytes                       = 15648
Reserved space for JIT data bytes    = -1
Maximum space for JIT data bytes     = -1
Zip cache bytes                      = 0
Data bytes                           = 114080
Metadata bytes                       = 37620
Metadata % used                      = 0%
Class debug area size                = 1331200
Class debug area used bytes          = 664446
Class debug area % used              = 49%

# ROMClasses                         = 961
# AOT Methods                        = 1
# Classpaths                         = 1
# URLs                               = 0
# Tokens                             = 0
# Zip caches                         = 0
# Stale classes                      = 0
% Stale classes                      = 0%

Cache is 26% full

Cache is accessible to current user = true
```

That's about 3MiB in terms of what gets shared. Class sharing could also be achieved similarly without OpenJ9 by process forking and copy-on-write as per this PR - so long as the jar files are named the same between processes. Thus, I don't see that class sharing or OpenJ9 savings are particularly worth it.

### Zulu
The Zulu JVM yields similar results to Hotspot.

### Java9
I tried Java9 in combination with jlink in order to strip out all unnecessary modules. No major diff.

Conclusion: still thinking of my original idea re. dynamic class loading along the lines of OSGi.