### PR TITLE
New signal handling and the elimination of stdin EOT

### DIFF
--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 ( \
+  printf "l" && \
   echo "-cp classes example.Hello" && \
-  tar -c -C $(pwd)/test/target/scala-2.12 classes &&
-  cat <&0 && \
-  printf '\04' \
-  ) | nc 127.0.0.1 9000
+  tar -c -C $(pwd)/test/target/scala-2.12 classes && \
+  cat <&0 \
+  ) | \
+nc 127.0.0.1 9000

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -5,8 +5,7 @@ import akka.actor.{ Actor, ActorLogging, PoisonPill, Props }
 import akka.pattern.pipe
 import akka.util.ByteString
 import akka.stream._
-import akka.stream.stage._
-import akka.stream.scaladsl.{ BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete, StreamConverters }
+import akka.stream.scaladsl.{ BroadcastHub, Keep, Source, StreamConverters }
 import java.io.{ ByteArrayOutputStream, PrintStream }
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
@@ -17,15 +16,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.Properties
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.FiniteDuration
 import scala.ref.WeakReference
 import scala.util.control.NonFatal
-import scala.util.Success
 
 object JvmExecutor {
   def props(
-    processId: String,
+    processId: Int,
     properties: ThreadGroupProperties, securityManager: ThreadGroupSecurityManager, useDefaultSecurityManager: Boolean, preventShutdownHooks: Boolean,
     stdin: ThreadGroupInputStream, stdinTimeout: FiniteDuration, stdout: ThreadGroupPrintStream, stderr: ThreadGroupPrintStream,
     in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]],
@@ -45,201 +43,6 @@ object JvmExecutor {
 
   case class StartProcess(commandLine: String, stdin: Source[ByteString, AnyRef])
   case class SignalProcess(signal: Int)
-
-  private[landlord] sealed abstract class ProcessInputPart
-  private[landlord] case class CommandLine(value: String) extends ProcessInputPart
-  private[landlord] case class Archive(value: Source[ByteString, AnyRef]) extends ProcessInputPart
-  private[landlord] case class Stdin(value: Source[ByteString, AnyRef]) extends ProcessInputPart
-  private[landlord] case class Signal(value: Int) extends ProcessInputPart
-
-  private[landlord] class ProcessParameterParser(implicit mat: ActorMaterializer, ec: ExecutionContext)
-    extends GraphStage[FlowShape[ByteString, ProcessInputPart]] {
-
-    private val in = Inlet[ByteString]("ProcessParameters.in")
-    private val out = Outlet[ProcessInputPart]("ProcessParameters.out")
-
-    override val shape: FlowShape[ByteString, ProcessInputPart] = FlowShape.of(in, out)
-
-    override def createLogic(attr: Attributes): GraphStageLogic =
-      new GraphStageLogic(shape) {
-
-        def receiveCommandLine(commandLine: StringBuilder)(bytes: ByteString): ByteString = {
-          val posn = bytes.indexOf('\n')
-          val (left, right) = bytes.splitAt(posn)
-          if (left.isEmpty) {
-            commandLine ++= right.utf8String
-            pull(in)
-            ByteString.empty
-          } else {
-            commandLine ++= left.utf8String
-            emit(out, CommandLine(commandLine.toString))
-            becomeReceiveTar()
-            val carry = right.drop(1)
-            if (carry.nonEmpty)
-              asyncReceive.invoke(())
-            else
-              pull(in)
-            carry
-          }
-        }
-
-        def becomeReceiveTar(): Unit = {
-          val (queue, ar) =
-            Source
-              .queue[ByteString](100, OverflowStrategy.backpressure)
-              .prefixAndTail(0)
-              .map {
-                case (_, arIn) => arIn
-              }
-              .toMat(Sink.head)(Keep.both)
-              .run
-          emit(out, Archive(Source.fromFutureSource(ar)))
-          become(receiveTar(queue, ByteString.empty))
-        }
-
-        private val Blocksize = 512
-        private val Eotsize = Blocksize * 2
-        private val BlockingFactor = 20
-        private val RecordSize = Blocksize * BlockingFactor
-        assert(RecordSize >= Eotsize)
-
-        def receiveTar(
-          queue: SourceQueueWithComplete[ByteString],
-          recordBuffer: ByteString)(bytes: ByteString): ByteString = {
-
-          val remaining = RecordSize - recordBuffer.size
-          val (add, carry) = bytes.splitAt(remaining)
-          val enqueueRecordBuffer = recordBuffer ++ add
-          if (enqueueRecordBuffer.size == RecordSize) {
-            val enqueued = new AtomicBoolean(false)
-            queue.offer(enqueueRecordBuffer).andThen {
-              case Success(QueueOfferResult.Enqueued) =>
-                enqueued.compareAndSet(false, true)
-                asyncReceive.invoke(())
-              case _ =>
-                asyncCancel.invoke(())
-            }
-            become(receiveTarQueuePending(queue, enqueueRecordBuffer, enqueued))
-          } else {
-            if (!hasBeenPulled(in)) pull(in)
-            become(receiveTar(queue, enqueueRecordBuffer))
-          }
-          carry
-        }
-
-        def receiveTarQueuePending(
-          queue: SourceQueueWithComplete[ByteString],
-          recordBuffer: ByteString,
-          enqueued: AtomicBoolean)(bytes: ByteString): ByteString = {
-
-          if (enqueued.get()) {
-            if (recordBuffer.takeRight(Eotsize).forall(_ == 0)) {
-              queue.complete()
-              becomeReceiveStdin()
-            } else {
-              become(receiveTar(queue, ByteString.empty))
-            }
-            receive(bytes)
-          } else
-            bytes
-        }
-
-        def becomeReceiveStdin(): Unit = {
-          val (queue, stdin) =
-            Source
-              .queue[ByteString](100, OverflowStrategy.backpressure)
-              .prefixAndTail(0)
-              .map {
-                case (_, stdinIn) => stdinIn
-              }
-              .toMat(Sink.head)(Keep.both)
-              .run
-          emit(out, Stdin(Source.fromFutureSource(stdin)))
-          become(receiveStdin(queue))
-        }
-
-        def receiveStdin(queue: SourceQueueWithComplete[ByteString])(bytes: ByteString): ByteString = {
-          val eotPosn = bytes.indexOf(4)
-          val (left, right) = if (eotPosn == -1) bytes -> ByteString.empty else bytes.splitAt(eotPosn)
-          if (left.nonEmpty) {
-            val enqueued = new AtomicBoolean(false)
-            queue.offer(left).andThen {
-              case Success(QueueOfferResult.Enqueued) =>
-                enqueued.compareAndSet(false, true)
-                asyncReceive.invoke(())
-              case _ =>
-                asyncCancel.invoke(())
-            }
-            become(receiveStdinQueuePending(queue, eotPosn, enqueued))
-          }
-          val carry = right.drop(1)
-          if (carry.nonEmpty)
-            asyncReceive.invoke(())
-          else if (!hasBeenPulled(in))
-            pull(in)
-          carry
-        }
-
-        def receiveStdinQueuePending(
-          queue: SourceQueueWithComplete[ByteString],
-          eotPosn: Int,
-          enqueued: AtomicBoolean)(bytes: ByteString): ByteString = {
-
-          if (enqueued.get()) {
-            if (eotPosn > -1) {
-              queue.complete()
-              become(receiveSignal(ByteString.empty))
-            } else {
-              become(receiveStdin(queue))
-            }
-            receive(bytes)
-          } else
-            bytes
-        }
-
-        def receiveSignal(recordBuffer: ByteString)(bytes: ByteString): ByteString = {
-          val RecordSize = 4
-          val remaining = RecordSize - recordBuffer.size
-          val (add, carry) = bytes.splitAt(remaining)
-          val newRecordBuffer = recordBuffer ++ add
-          if (newRecordBuffer.size == RecordSize) {
-            emit(out, Signal(newRecordBuffer.iterator.getInt(ByteOrder.BIG_ENDIAN)))
-            become(receiveFinished())
-          } else {
-            become(receiveSignal(newRecordBuffer))
-            if (!hasBeenPulled(in)) pull(in)
-          }
-          carry
-        }
-
-        def receiveFinished()(bytes: ByteString): ByteString =
-          ByteString.empty
-
-        def become(receiver: ByteString => ByteString): Unit =
-          receive = receiver
-        private var receive: ByteString => ByteString = receiveCommandLine(new StringBuilder)
-        private var carry: ByteString = ByteString.empty
-
-        private var asyncReceive: AsyncCallback[Unit] = _
-        private var asyncCancel: AsyncCallback[Unit] = _
-
-        override def preStart(): Unit = {
-          asyncReceive = getAsyncCallback[Unit](_ => carry = receive(carry))
-          asyncCancel = getAsyncCallback[Unit](_ => cancel(in))
-          pull(in)
-        }
-
-        setHandler(in, new InHandler {
-          override def onPush(): Unit =
-            carry = receive(carry ++ grab(in))
-        })
-
-        setHandler(out, new OutHandler {
-          override def onPull(): Unit =
-            if (!hasBeenPulled(in)) pull(in)
-        })
-      }
-  }
 
   private[landlord] class BoundedByteArrayOutputStream extends ByteArrayOutputStream {
     val MaxOutputSize = 8192
@@ -291,6 +94,9 @@ object JvmExecutor {
   private[landlord] def sizeToBytes(size: Int): ByteString =
     ByteString.newBuilder.putInt(size)(ByteOrder.BIG_ENDIAN).result()
 
+  private[landlord] def processIdToBytes(processId: Int): ByteString =
+    ByteString.newBuilder.putInt(processId)(ByteOrder.BIG_ENDIAN).result()
+
   private[landlord] def exitStatusToBytes(statusCode: Int): ByteString =
     ByteString.newBuilder.putByte('x').putInt(statusCode)(ByteOrder.BIG_ENDIAN).result()
 
@@ -308,25 +114,13 @@ object JvmExecutor {
  * world appearing close to what it would look like as if it were invoked directly. The
  * executor is also responsible for terminating the process.
  *
- * The executor is constructed with a stream through which `java` command line args are
- * received along with a tar filesystem to read from followed by stdin and a signal. An outward
- * stream is also provided for transmitting stdout, stderr and the process's final exit code.
- *
- * The following specifications assume big-endian byte order.
- *
- * The incoming stream is presented as follows:
- *
- * 1. The first line (up until a LF) are the command line args to pass to the `java` command.
- *    The arguments are decoded as UTF-8.
- * 2. The next line represents the binary tar file output of the file system that the `java`
- *    command and its host program will ultimately read from e.g. containing the class files.
- * 3. The stream then represents stdin until an EOT is received. The input is decoded as UTF-8.
- * 4. The remaining stream will consist of a four byte integer representing a signal code
- *    and which will also terminate the stream.
+ * The incoming stream is parsed via the ProcessParameterParser stage. See its doco for a
+ * full description.
  *
  * The outgoing stream is presented as follows:
  *
- * 1. A single UTF-8 character representing one of 'o', 'e' or 'x' (stdout, stderr, exit code).
+ * 1. The first four bytes convey the process id.
+ * 2. A single UTF-8 character is then sent representing one of 'o', 'e' or 'x' (stdout, stderr, exit code).
  *
  * In the case of 'o' or 'e' then there is a four byte integer providing the length of the
  * UTF-8 characters to follow.
@@ -336,7 +130,7 @@ object JvmExecutor {
  * transmitted.
  */
 class JvmExecutor(
-    processId: String,
+    processId: Int,
     properties: ThreadGroupProperties, securityManager: ThreadGroupSecurityManager, useDefaultSecurityManager: Boolean, preventShutdownHooks: Boolean,
     stdin: ThreadGroupInputStream, stdinTimeout: FiniteDuration, stdout: ThreadGroupPrintStream, stderr: ThreadGroupPrintStream,
     in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]],
@@ -359,9 +153,9 @@ class JvmExecutor(
     in
       .via(new ProcessParameterParser)
       .runFoldAsync("") {
-        case (_, CommandLine(value)) =>
+        case (_, ProcessParameterParser.CommandLine(value)) =>
           Future.successful(value)
-        case (cl, Archive(value)) =>
+        case (cl, ProcessParameterParser.Archive(value)) =>
           TarStreamWriter
             .writeTarStream(
               value,
@@ -369,11 +163,8 @@ class JvmExecutor(
               context.system.dispatchers.lookup("akka.actor.default-blocking-io-dispatcher")
             )
             .map(_ => cl)
-        case (cl, Stdin(value)) =>
+        case (cl, ProcessParameterParser.Stdin(value)) =>
           self ! StartProcess(cl, value)
-          Future.successful(cl)
-        case (cl, Signal(value)) =>
-          self ! SignalProcess(value)
           Future.successful(cl)
       }
       .recover {
@@ -496,15 +287,18 @@ class JvmExecutor(
               )
 
             out.success(
-              stdoutSource
-                .map(bytes => StdoutPrefix ++ sizeToBytes(bytes.size) ++ bytes)
-                .merge(stderrSource.map(bytes => StderrPrefix ++ sizeToBytes(bytes.size) ++ bytes))
+              Source.single(processIdToBytes(processId))
                 .concat(
-                  Source.fromFuture(
-                    exitStatusPromise
-                      .future
-                      .map(exitStatusToBytes)
-                  )
+                  stdoutSource
+                    .map(bytes => StdoutPrefix ++ sizeToBytes(bytes.size) ++ bytes)
+                    .merge(stderrSource.map(bytes => StderrPrefix ++ sizeToBytes(bytes.size) ++ bytes))
+                    .concat(
+                      Source.fromFuture(
+                        exitStatusPromise
+                          .future
+                          .map(exitStatusToBytes)
+                      )
+                    )
                 )
                 .watchTermination()(stopSelfWhenDone)
             )
@@ -531,7 +325,7 @@ class JvmExecutor(
       out.success(
         Source
           .single {
-            errorMessage.fold(ByteString.empty)(e => StderrPrefix ++ ByteString(e)) ++
+            errorMessage.fold(processIdToBytes(processId))(e => StderrPrefix ++ ByteString(e)) ++
               exitStatusToBytes(exitStatus)
           }
           .watchTermination()(stopSelfWhenDone)

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
@@ -1,0 +1,222 @@
+package com.github.huntc.landlord
+
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.stream._
+import akka.stream.scaladsl.{ Keep, Sink, Source, SourceQueueWithComplete }
+import akka.stream.stage._
+import akka.util.ByteString
+
+import scala.concurrent.ExecutionContext
+import scala.util.Success
+
+object ProcessParameterParser {
+
+  sealed abstract class ProcessInputPart
+
+  case class CommandLine(value: String) extends ProcessInputPart
+
+  case class Archive(value: Source[ByteString, AnyRef]) extends ProcessInputPart
+
+  case class Stdin(value: Source[ByteString, AnyRef]) extends ProcessInputPart
+
+  class UnexpectedEOS(suffix: String) extends RuntimeException("Unexpected end of stream while receiving " + suffix)
+}
+
+/**
+ * This stage describes stream parsing through which `java` command line args are
+ * received along with a tar filesystem to read from followed by stdin and a signal.
+ *
+ * The following specifications assume big-endian byte order.
+ *
+ * The stream is presented as follows:
+ *
+ * 1. The first line (up until a LF) are the command line args to pass to the `java` command.
+ *    The arguments are decoded as UTF-8.
+ * 2. The next line represents the binary tar file output of the file system that the `java`
+ *    command and its host program will ultimately read from e.g. containing the class files.
+ * 3. The stream then represents stdin until the stream is completed. The input is decoded as UTF-8.
+ *
+ */
+class ProcessParameterParser(implicit mat: ActorMaterializer, ec: ExecutionContext)
+  extends GraphStage[FlowShape[ByteString, ProcessParameterParser.ProcessInputPart]] {
+
+  import ProcessParameterParser._
+
+  private val in = Inlet[ByteString]("ProcessParameters.in")
+  private val out = Outlet[ProcessInputPart]("ProcessParameters.out")
+
+  override val shape: FlowShape[ByteString, ProcessInputPart] = FlowShape.of(in, out)
+
+  override def createLogic(attr: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+
+      def receiveCommandLine(commandLine: StringBuilder)(bytes: ByteString): ByteString = {
+        val posn = bytes.indexOf('\n')
+        val (left, right) = bytes.splitAt(posn)
+        if (left.isEmpty) {
+          commandLine ++= right.utf8String
+          pull(in)
+          ByteString.empty
+        } else {
+          commandLine ++= left.utf8String
+          emit(out, CommandLine(commandLine.toString))
+          becomeReceiveTar()
+          val carry = right.drop(1)
+          if (carry.nonEmpty)
+            asyncReceive.invoke(())
+          else
+            pull(in)
+          carry
+        }
+      }
+
+      def becomeReceiveTar(): Unit = {
+        val (queue, ar) =
+          Source
+            .queue[ByteString](100, OverflowStrategy.backpressure)
+            .prefixAndTail(0)
+            .map {
+              case (_, arIn) => arIn
+            }
+            .toMat(Sink.head)(Keep.both)
+            .run
+        emit(out, Archive(Source.fromFutureSource(ar)))
+        become(receiveTar(queue, ByteString.empty))
+      }
+
+      private val Blocksize = 512
+      private val Eotsize = Blocksize * 2
+      private val BlockingFactor = 20
+      private val RecordSize = Blocksize * BlockingFactor
+      assert(RecordSize >= Eotsize)
+
+      def receiveTar(
+        queue: SourceQueueWithComplete[ByteString],
+        recordBuffer: ByteString)(bytes: ByteString): ByteString = {
+
+        val remaining = RecordSize - recordBuffer.size
+        val (add, carry) = bytes.splitAt(remaining)
+        val enqueueRecordBuffer = recordBuffer ++ add
+        if (enqueueRecordBuffer.size == RecordSize) {
+          val enqueued = new AtomicBoolean(false)
+          queue.offer(enqueueRecordBuffer).andThen {
+            case Success(QueueOfferResult.Enqueued) =>
+              enqueued.compareAndSet(false, true)
+              asyncReceive.invoke(())
+            case _ =>
+              asyncCancel.invoke(())
+          }
+          become(receiveTarQueuePending(queue, enqueueRecordBuffer, enqueued))
+        } else {
+          if (!isClosed(in)) {
+            if (!hasBeenPulled(in)) pull(in)
+          } else {
+            failStage(new UnexpectedEOS("archive"))
+          }
+          become(receiveTar(queue, enqueueRecordBuffer))
+        }
+        carry
+      }
+
+      def receiveTarQueuePending(
+        queue: SourceQueueWithComplete[ByteString],
+        recordBuffer: ByteString,
+        enqueued: AtomicBoolean)(bytes: ByteString): ByteString = {
+
+        if (enqueued.get()) {
+          if (recordBuffer.takeRight(Eotsize).forall(_ == 0)) {
+            queue.complete()
+            becomeReceiveStdin()
+          } else {
+            become(receiveTar(queue, ByteString.empty))
+          }
+          receive(bytes)
+        } else
+          bytes
+      }
+
+      def becomeReceiveStdin(): Unit = {
+        val (queue, stdin) =
+          Source
+            .queue[ByteString](100, OverflowStrategy.backpressure)
+            .prefixAndTail(0)
+            .map {
+              case (_, stdinIn) => stdinIn
+            }
+            .toMat(Sink.head)(Keep.both)
+            .run
+        emit(out, Stdin(Source.fromFutureSource(stdin)))
+        become(receiveStdin(queue))
+      }
+
+      def receiveStdin(queue: SourceQueueWithComplete[ByteString])(bytes: ByteString): ByteString = {
+        if (bytes.nonEmpty) {
+          val enqueued = new AtomicBoolean(false)
+          queue.offer(bytes).andThen {
+            case Success(QueueOfferResult.Enqueued) =>
+              enqueued.compareAndSet(false, true)
+              asyncReceive.invoke(())
+            case _ =>
+              asyncCancel.invoke(())
+          }
+          become(receiveStdinQueuePending(queue, enqueued))
+          if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
+        } else if (isClosed(in)) {
+          completeStage()
+          become(receiveFinished())
+        }
+        ByteString.empty
+      }
+
+      def receiveStdinQueuePending(
+        queue: SourceQueueWithComplete[ByteString],
+        enqueued: AtomicBoolean)(bytes: ByteString): ByteString = {
+
+        if (enqueued.get()) {
+          if (isClosed(in)) {
+            queue.complete()
+            completeStage()
+            become(receiveFinished())
+          } else {
+            become(receiveStdin(queue))
+          }
+          receive(bytes)
+        } else
+          bytes
+      }
+
+      def receiveFinished()(bytes: ByteString): ByteString =
+        ByteString.empty
+
+      def become(receiver: ByteString => ByteString): Unit =
+        receive = receiver
+      private var receive: ByteString => ByteString = receiveCommandLine(new StringBuilder)
+
+      private var carry: ByteString = ByteString.empty
+
+      private var asyncReceive: AsyncCallback[Unit] = _
+      private var asyncCancel: AsyncCallback[Unit] = _
+
+      override def preStart(): Unit = {
+        asyncReceive = getAsyncCallback[Unit](_ => carry = receive(carry))
+        asyncCancel = getAsyncCallback[Unit](_ => cancel(in))
+        pull(in)
+      }
+
+      setHandler(in, new InHandler {
+        override def onPush(): Unit =
+          carry = receive(carry ++ grab(in))
+
+        override def onUpstreamFinish(): Unit =
+          asyncReceive.invoke(())
+      })
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit =
+          if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
+      })
+    }
+}
+

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/MainSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/MainSpec.scala
@@ -1,0 +1,73 @@
+package com.github.huntc.landlord
+
+import java.nio.ByteOrder
+
+import akka.NotUsed
+import akka.actor.{ Actor, ActorSelection, ActorSystem, Props }
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.ActorMaterializer
+import akka.testkit._
+import akka.util.ByteString
+import org.scalatest._
+
+import scala.concurrent.Promise
+import scala.util.Try
+
+class MainSpec extends TestKit(ActorSystem("MainSpec"))
+  with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val ma: ActorMaterializer = ActorMaterializer()
+
+  def emptyLaunchInfoOp(in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]]): (Int, Props) =
+    0 -> Props.empty
+
+  def emptySendKillOp(jvmExecutor: ActorSelection, signal: Int): Unit =
+    ()
+
+  "Main" should {
+    "process input for launching a process" in {
+      def launchInfoOp(in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]]): (Int, Props) =
+        123 -> Props(new Actor {
+          override def preStart(): Unit = {
+            in
+              .runWith(Sink.head)
+              .foreach(input => out.success(Source.single(input)))
+          }
+          def receive: Receive = {
+            case _ =>
+          }
+        })
+
+      Source
+        .single(ByteString("lsomeinput"))
+        .via(Main.controlFlow(launchInfoOp, emptySendKillOp))
+        .runWith(Sink.head)
+        .map(r => assert(r.utf8String == "someinput"))
+    }
+
+    "receive a process id and signal when killing a process" in {
+      val result = Promise[Assertion]()
+      def sendKillOp(jvmExecutor: ActorSelection, signal: Int): Unit =
+        result.complete(Try(assert(jvmExecutor.pathString == "/user/123" && signal == 15)))
+
+      Source
+        .single(ByteString.newBuilder.putByte('k').putInts(Array(123, 15))(ByteOrder.BIG_ENDIAN).result())
+        .via(Main.controlFlow(emptyLaunchInfoOp, sendKillOp))
+        .runWith(Sink.ignore)
+
+      result.future
+    }
+
+    "receive ??? with an unknown command" in {
+      Source
+        .single(ByteString.newBuilder.putByte('z').result())
+        .via(Main.controlFlow(emptyLaunchInfoOp, emptySendKillOp))
+        .runWith(Sink.head)
+        .map(r => assert(r.utf8String == "???"))
+    }
+  }
+}

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/ProcessParameterParserSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/ProcessParameterParserSpec.scala
@@ -1,0 +1,72 @@
+package com.github.huntc.landlord
+
+import java.io.ByteArrayOutputStream
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.stream.ActorMaterializer
+import akka.testkit._
+import akka.util.ByteString
+import org.apache.commons.compress.archivers.ArchiveStreamFactory
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.scalatest._
+
+import scala.concurrent.Future
+
+class ProcessParameterParserSpec extends TestKit(ActorSystem("ProcessParameterParserSpec"))
+  with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val ma: ActorMaterializer = ActorMaterializer()
+
+  "The ProcessParameterParser" should {
+    "produce a flow of ProcessInputParts in the required order given a valid input" in {
+      val cl = "some args"
+
+      val tar = {
+        val bos = new ByteArrayOutputStream()
+        val tos =
+          new ArchiveStreamFactory()
+            .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)
+            .asInstanceOf[TarArchiveOutputStream]
+        try {
+          tos.flush()
+          tos.finish()
+        } finally {
+          tos.close()
+        }
+        bos.toByteArray
+      }
+
+      val stdinStr = "some stdin\nsome more stdin\n"
+
+      val TarRecordSize = 10240
+
+      Source
+        .single(
+          ByteString(cl + "\n") ++
+            ByteString(tar) ++
+            ByteString(stdinStr)
+        )
+        .via(new ProcessParameterParser)
+        .runFoldAsync(0 -> succeed) {
+          case ((ordinal, _), ProcessParameterParser.CommandLine(v)) =>
+            Future.successful(1 -> assert(ordinal == 0 && v == cl))
+          case ((ordinal, _), ProcessParameterParser.Archive(v)) =>
+            val complete = v.runFold(0L)(_ + _.size)
+            complete.map(tarSize => 2 -> assert(ordinal == 1 && tarSize == TarRecordSize))
+          case ((ordinal, _), ProcessParameterParser.Stdin(v)) =>
+            val complete = v.runFold("")(_ ++ _.utf8String)
+            complete.map(input => 3 -> assert(ordinal == 2 && input == stdinStr))
+        }
+        .map {
+          case (count, Succeeded) if count == 3 => Succeeded
+          case (count, Succeeded)               => assert(count == 3)
+          case (_, lastAssertion)               => lastAssertion
+        }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3 

Also:
* Fixed a long-standing issue with the process input parser I was having with Source.single completing early.
* Provides launch/kill command
* Communicate process id via output
* Moved the process parameter parser into its own file