### PR TITLE
Allow additional (non-JVM) options to be passed

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
@@ -33,7 +33,9 @@ object ProcessParameterParser {
  * The stream is presented as follows:
  *
  * 1. The first line (up until a LF) are the command line args to pass to the `java` command.
- *    The arguments are decoded as UTF-8.
+ *    The arguments are decoded as UTF-8. Note that any non-JVM options that are to be passed to the
+ *    program itself should follow a "--" option e.g.:
+ *      -cp some.jar example.Hello -- -b http://127.0.0.1:8080/conn
  * 2. The next line represents the binary tar file output of the file system that the `java`
  *    command and its host program will ultimately read from e.g. containing the class files.
  * 3. The stream then represents stdin until the stream is completed. The input is decoded as UTF-8.

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -45,6 +45,12 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
       val parsed = JvmExecutor.parser.parse(List("mainclass", "mainarg0", "mainarg1"), JvmExecutor.JavaConfig())
       assert(parsed.contains(JvmExecutor.JavaConfig(List.empty, "mainclass", List("mainarg0", "mainarg1"))))
     }
+
+    "Return the main class, main options and args" in {
+      val (parseArgs, mainArgs) = JvmExecutor.splitMainArgs(Array("mainclass", "mainarg0", "--", "-o", "mainopt0"))
+      val parsed = JvmExecutor.parser.parse(parseArgs, JvmExecutor.JavaConfig(mainArgs = mainArgs))
+      assert(parsed.contains(JvmExecutor.JavaConfig(List.empty, "mainclass", List("-o", "mainopt0", "mainarg0"))))
+    }
   }
 
   "The classpath resolver" should {


### PR DESCRIPTION
Any non-JVM options need to be passed on to the program as-is i.e. not be interpreted by the JvmExecutor.