### PR TITLE
Numerous fixes

### DIFF
--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -65,8 +65,8 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
       Files.createFile(base.resolve("lib/a.class"))
       Files.createFile(base.resolve("lib/b.jar"))
       Files.createFile(base.resolve("lib/c.txt"))
-      val resolved = JvmExecutor.resolvePaths(base, Paths.get("lib/*")).toList
-      assert(resolved === List(base.resolve("lib/a.class"), base.resolve("lib/b.jar")))
+      val resolved = JvmExecutor.resolvePaths(base, Paths.get("lib/*")).toSet
+      assert(resolved === Set(base.resolve("lib/a.class"), base.resolve("lib/b.jar")))
     }
   }
 

--- a/landlordd/project/Dependencies.scala
+++ b/landlordd/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.Resolver.bintrayRepo
 
 object Versions {
   lazy val akka = "2.5.8"
-  lazy val alpakka = "0.16"
+  lazy val alpakka = "0.18"
   lazy val commonsCompress = "1.15"
   lazy val logbackClassic = "1.2.3"
   lazy val scalaTest = "3.0.4"


### PR DESCRIPTION
1) Tests were failing for me on my system: ```Linux meddle 4.15.13-1-ARCH #1 SMP PREEMPT Sun Mar 25 11:27:57 UTC 2018 x86_64 GNU/Linux``` with

```
[info] The classpath resolver
[info] - should resolve a non-glob
[info] - should resolve a glob *** FAILED ***
[info]   List(/tmp/classpath-resolver-spec2287179746786096411/lib/b.jar, /tmp/classpath-resolver-spec2287179746786096411/lib/a.class) did not equal List(/tmp/classpath-resolver-spec2287179746786096411/lib/a.class, /tmp/classpath-resolver-spec2287179746786096411/lib/b.jar) (JvmExecutorSpec.scala:69)
```

Seems that `Files.newDirectoryStream` output order can differ on systems (I suppose it would be FS-dependent), so changed the test to compare `Set` instead.

2) Upgrade alpakka to fix this: https://github.com/akka/alpakka/pull/840