### PR TITLE
Implement landlord

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,40 @@
-language: scala
+matrix:
+  include:
+    # landlordd (daemon)
+    - language: scala
+      cache:
+        directories:
+          - $HOME/.ivy2/cache
+          - $HOME/.sbt/launchers
+      before_cache:
+        # Ensure changes to the cache aren't persisted
+        - rm -rf $HOME/.ivy2/cache/com/github/huntc/landlord
+        # Delete all ivydata files since ivy touches them on each build
+        - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+      before_script:
+        - cd landlordd
+        - unset _JAVA_OPTIONS
 
-before_script: 
-  - cd landlordd
-  - unset _JAVA_OPTIONS
+    # landlord (CLI)
+    - language: rust
+      before_script:
+        - cd landlord
 
+    # integration test (landlordd <--> landlord)
+    - language: scala
+      cache:
+        directories:
+          - $HOME/.ivy2/cache
+          - $HOME/.sbt/launchers
+      before_cache:
+        # Ensure changes to the cache aren't persisted
+        - rm -rf $HOME/.ivy2/cache/com/github/huntc/landlord
+        # Delete all ivydata files since ivy touches them on each build
+        - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+      install:
+        - curl https://sh.rustup.rs/ | sh -s -- -y
+      before_script:
+        - unset _JAVA_OPTIONS
+        - export PATH="$HOME/.cargo/bin:$PATH"
+      script:
+        - scripts/integration-test-cli

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ JVM programs take up too much resident memory. Back in the day of Java 1.1, a mi
 
 Also, compare a typical JVM "microservice" to one written using a native target, such as LLVM; the JVM one will occupy around 350MiB which is more than 10 times the amount of memory when compared to a native one written in, say, Go. The JVM's consumption of memory may have been fine for the monolith, but when it comes to running many JVM based microservices (processes), their resident memory usage makes you want to program in something closer to the metal... or seek the "landlord" project!
 
-Discounting the regular JVM overhead of runnning the first service, Running Landlord will reduce a typical "hello world" down to the requirements of its classpath. I've observed a simple Java Hello World app consuming less than 1MiB of memory compared to 35MiB when running as a standalone process. Bear in mind though that landlordd itself will realistically require 250MiB including room for running several processes (all depending on what the processes require of course!). 
+Discounting the regular JVM overhead of runnning the first service, Running Landlord will reduce a typical "hello world" down to the requirements of its classpath. I've observed a simple Java Hello World app consuming less than 1MiB of memory compared to 35MiB when running as a standalone process. Bear in mind though that landlordd itself will realistically require 250MiB including room for running several processes (all depending on what the processes require of course!).
 
 ## What
-Landlord has a daemon service named `landlordd`. `landlordd` launches the JVM and runs some code that provides a secure Unix socket domain service where you can submit your JVM program to run. You may also send various [POSIX signals](https://en.wikipedia.org/wiki/Signal_(IPC)) that are trapped by your program in the conventional way for the JVM. You manage the daemon's lifecycle as per other services on your machines e.g. via initd. 
+Landlord has a daemon service named `landlordd`. `landlordd` launches the JVM and runs some code that provides a secure Unix socket domain service where you can submit your JVM program to run. You may also send various [POSIX signals](https://en.wikipedia.org/wiki/Signal_(IPC)) that are trapped by your program in the conventional way for the JVM. You manage the daemon's lifecycle as per other services on your machines e.g. via initd.
 
 A client is also provided and named `landlord`. This client interfaces with `landlordd` and accepts a filesystem via stdin. The client provides the illusion that your program is running within it, in the same way that Docker clients do when they run containers via the Docker daemon. Landlord's architecture is very similar to Docker in this way i.e. there are clients and there is a daemon. One important difference though is that when your client terminates, so does its "process" as managed by its daemon i.e. there is deliberately no "detach" mode in order to reduce the potential for orphaned processes. Landlord clients themselves can be detached though. The goal is for the Landlord client to behave as your process would without Landlord, relaying signals etc.
 
 ## How
 From the command line, simply use the `landlord` command instead of the `java` tool and pass its filesystem via tar on `stdin` and you're good to go.
 
-Under the hood, `landlord` will use a usergroup-secured Unix domain socket to send its arguments, including the streaming of the `tar` based file system from `stdin`. `landlordd` will consume the stream and create a new internal process invoked with a similar `java` command to the one it was invoked with. 
+Under the hood, `landlord` will use a usergroup-secured Unix domain socket to send its arguments, including the streaming of the `tar` based file system from `stdin`. `landlordd` will consume the stream and create a new internal process invoked with a similar `java` command to the one it was invoked with.
 
 landlordd emulates the forking of a process within the same JVM by providing:
 * a new classloader for each process that prohibits looking up landlord's and other process classes
@@ -80,12 +80,11 @@ Upon compiling and supposing a folder containing our "hello world" class at `./h
 
 > Note that the `landlord` client is not yet written. In order to launch landlordd, seeing [the section on building below](#Building)
 
-```
+```bash
 tar -c . | landlord -cp ./hello-world/out/production/hello-world Main
 ```
 
 ## Considerations/trade-offs
-
 Some tradeoffs that have been identified:
 
 * Multi-tenancy can introduce headaches because of inability to quota the heap and reason about how JIT and GC work for the aggregate JVM. However, this is a trade-off that OSGi has also accepted.
@@ -102,20 +101,20 @@ Some tradeoffs that have been identified:
 
 Thanks to @retronym, @dragos and @dotta for their contributions to the above.
 
-## landlord (TODO)
-`landlord` will stream your commands to `landlordd` and then wait on a response. The response will yield the exit code from your program which will then cause `landlord` exit with the same response code.
+## landlord
+`landlord` (the client) streams stdin to `landlordd` until it receives a response. The response yields the exit code from your program which will then cause `landlord` exit with the same response code.
 
 Any POSIX signals sent to `landlord` while it is waiting for a reply will be forwarded onto `landlordd` and are then received by your program.
 
-Note that in the case of long-lived programs (the most typical scenario for a microservice at least), then `landlord` will not return until your program terminates.
+Note that in the case of long-lived programs (the most typical scenario for a microservice at least), `landlord` will not return until your program terminates.
 
 ## landlordd
 You can run as many `landlordd` daemons as your system will allow. Quite often though, you should just need one.
 
-## Building
+## Building landlordd
 1. Build the daemon:
 
-```
+```bash
 cd landlord/landlordd/
 sbt daemon/stage
 ```
@@ -123,16 +122,19 @@ sbt daemon/stage
 2. Run it - `/var/run/landlordd` is where the Unix Domain Socket will be created and `/tmp/a` is simply where forked processes will run within:
 
 ```
-sudo mkdir /var/run/landlordd
-chown $USER /var/run/landlordd
+sudo mkdir /var/run/landlord
+sudo chown $USER /var/run/landlord
+sudo chmod 770 /var/run/landlord
 daemon/target/universal/stage/bin/landlordd --process-dir-path=/tmp/a
 ```
 
 You should see `Ready.` output when the daemon is ready to receive requests.
 
-3. From another terminal, launch a bash script that will connect to it, along with invoking a sample HelloWorld we have:
+3. From another terminal, launch a bash script that will connect to it, along with invoking a sample HelloWorld we have.
 
-```
+> This bash script is only an example to demonstrate how `landlordd` works. To actually launch your processes, you'll want to use the `landlord` client described later in this README.
+
+```bash
 cd landlord/landlordd/
 ./client.sh
 ```
@@ -155,6 +157,22 @@ x
 `Hi there` is what I typed in. The `o` and `Hi there` is the stdout and the `x` is the exit code. We're not seeing some values such as the string length and actual exit code because the bash echo command is not outputting them (we'll write a more sophisticated native client down the track).
 
 The bash script expects you to just hit return to end sending stdin.
+
+## Building landlord
+`landlord` is a CLI program written in [Rust](https://www.rust-lang.org/en-US/). You'll need `cargo` on your path to build it, see [rustup](https://www.rustup.rs/) for more information.
+
+### Dev
+```bash
+cd landlord
+cargo run -- -cp ../landlordd/test/target/scala-2.12/classes example.Hello
+```
+
+### Release
+```bash
+cd landlord
+cargo build --release
+./target/release/landlord
+```
 
 Profiling tooling is gratefully donated by YourKit LLC ![logo](https://www.yourkit.com/images/yklogo.png)
 

--- a/landlord/.gitignore
+++ b/landlord/.gitignore
@@ -1,0 +1,2 @@
+target/
+.idea/

--- a/landlord/Cargo.lock
+++ b/landlord/Cargo.lock
@@ -1,0 +1,175 @@
+[[package]]
+name = "bit-set"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "chan-signal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "filetime"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "landlord"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tar"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xattr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
+"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "9af7c487bb99c929ba2715b1a3a7bf45f5062bf5b6eae5d32b292a96c5865172"
+"checksum chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f1f1e11f6e1c14c9e805a87c622cb8fcb636283b3119a2150af390cc6702d7fe"
+"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"

--- a/landlord/Cargo.toml
+++ b/landlord/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "landlord"
+version = "0.1.0"
+authors = ["Jason Longshore <longshorej@gmail.com>"]
+
+[dependencies]
+byteorder = "1.2.2"
+chan-signal = "0.3.1"
+libc = "0.2"
+tar = "0.4"

--- a/landlord/src/args.rs
+++ b/landlord/src/args.rs
@@ -1,0 +1,273 @@
+#[derive(PartialEq, Debug)]
+pub enum ExecutionMode {
+    Class { class: String, args: Vec<String> },
+    Exit { code: i32 },
+    Help { code: i32 },
+    JarFile { file: String, args: Vec<String> },
+}
+
+#[derive(PartialEq, Debug)]
+pub struct JavaArgs {
+    pub cp: Vec<String>,
+    pub errors: Vec<String>,
+    pub mode: ExecutionMode,
+    pub props: Vec<(String, String)>,
+    pub socket: String,
+    pub version: bool,
+}
+
+pub fn parse_java_args(args: &Vec<String>) -> JavaArgs {
+    // We want to aim to be a drop-in replacement for java, so we have to roll our own arg parser
+    // because DocOpt/Clap/et al don't have the required features to match the rather strange java
+    // arguments.
+
+    let noop_flags = vec![
+        "-server".to_string(),
+        "-d64".to_string(),
+        "-d32".to_string(),
+    ];
+
+    let mut jargs = JavaArgs {
+        cp: vec![".".to_string()],
+        errors: vec![],
+        mode: ExecutionMode::Help { code: 1 },
+        props: vec![],
+        socket: "/var/run/landlord/landlordd.sock".to_string(),
+        version: false,
+    };
+
+    let mut iter = args.iter();
+
+    loop {
+        let next = iter.next();
+
+        match next {
+            Some(entry) if !entry.starts_with("-") => {
+                let mut items = vec![];
+
+                while let Some(next) = iter.next() {
+                    items.push(next.to_string());
+                }
+
+                jargs.mode = ExecutionMode::Class {
+                    class: entry.to_string(),
+                    args: items,
+                }
+            }
+
+            Some(flag) if flag == "-jar" => {
+                if let Some(file) = iter.next() {
+                    let mut items = vec![];
+
+                    while let Some(next) = iter.next() {
+                        items.push(next.to_string());
+                    }
+
+                    jargs.mode = ExecutionMode::JarFile {
+                        file: file.to_string(),
+                        args: items,
+                    };
+                } else {
+                    jargs
+                        .errors
+                        .push(format!("{} requires jar file specification", flag))
+                }
+            }
+
+            Some(flag) if flag == "-?" || flag == "-help" => {
+                jargs.mode = ExecutionMode::Help { code: 0 };
+            }
+
+            Some(flag) if flag == "-version" => {
+                jargs.version = true;
+                jargs.mode = ExecutionMode::Exit { code: 0 };
+            }
+
+            Some(flag) if flag == "-showversion" => {
+                jargs.version = true;
+            }
+
+            Some(flag) if flag == "-cp" || flag == "-classpath" => {
+                if let Some(cp) = iter.next() {
+                    jargs.cp = cp.split(":").map(|s| s.to_string()).collect();
+                } else {
+                    jargs
+                        .errors
+                        .push(format!("{} requires class path specification", flag))
+                }
+            }
+
+            Some(flag) if flag == "-socket" => {
+                if let Some(socket) = iter.next() {
+                    jargs.socket = socket.to_string();
+                } else {
+                    jargs
+                        .errors
+                        .push(format!("{} requires socket specification", flag))
+                }
+            }
+
+            Some(flag) if flag.starts_with("-D") => {
+                if let Some(s) = flag.get(2..) {
+                    let parts: Vec<&str> = s.splitn(2, "=").collect();
+
+                    if parts.len() == 2 {
+                        jargs
+                            .props
+                            .push((parts[0].to_string(), parts[1].to_string()));
+                    }
+                }
+            }
+
+            Some(flag) if noop_flags.contains(flag) => {}
+
+            Some(flag) => jargs.errors.push(format!("Unrecognized option: {}", flag)),
+
+            None => {
+                return jargs;
+            }
+        }
+    }
+}
+
+#[test]
+fn test_parse_java_args_help() {
+    assert_eq!(
+        parse_java_args(&vec!["-?".to_string()]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::Help { code: 0 },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: false,
+        }
+    );
+
+    assert_eq!(
+        parse_java_args(&vec!["-help".to_string()]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::Help { code: 0 },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: false,
+        }
+    );
+}
+
+#[test]
+fn test_parse_java_version() {
+    assert_eq!(
+        parse_java_args(&vec!["-version".to_string()]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::Exit { code: 0 },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: true,
+        }
+    );
+}
+
+#[test]
+fn test_parse_java_showversion() {
+    assert_eq!(
+        parse_java_args(&vec![
+            "-showversion".to_string(),
+            "-jar".to_string(),
+            "test.jar".to_string(),
+        ]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::JarFile {
+                file: "test.jar".to_string(),
+                args: vec![],
+            },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: true,
+        }
+    );
+}
+
+#[test]
+fn test_parse_java_jar() {
+    assert_eq!(
+        parse_java_args(&vec![
+            "-jar".to_string(),
+            "test.jar".to_string(),
+            "arg1".to_string(),
+            "arg2".to_string(),
+        ]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::JarFile {
+                file: "test.jar".to_string(),
+                args: vec!["arg1".to_string(), "arg2".to_string()],
+            },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: false,
+        }
+    );
+}
+
+#[test]
+fn test_all() {
+    assert_eq!(
+        parse_java_args(&vec![
+            "-Dkey1=value1".to_string(),
+            "-Dkey2=value2".to_string(),
+            "-d32".to_string(),
+            "-d64".to_string(),
+            "-server".to_string(),
+            "-socket".to_string(),
+            "/dev/null".to_string(),
+            "-cp".to_string(),
+            "/lib:/usr/lib".to_string(),
+            "com.hello.Example".to_string(),
+            "myarg one".to_string(),
+            "myargtwo".to_string(),
+        ]),
+        JavaArgs {
+            cp: vec!["/lib".to_string(), "/usr/lib".to_string()],
+            errors: vec![],
+            mode: ExecutionMode::Class {
+                class: "com.hello.Example".to_string(),
+                args: vec!["myarg one".to_string(), "myargtwo".to_string()],
+            },
+            props: vec![
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string()),
+            ],
+            socket: "/dev/null".to_string(),
+            version: false,
+        }
+    );
+}
+
+#[test]
+fn test_invalid_flags() {
+    assert_eq!(
+        parse_java_args(&vec![
+            "-hello-world".to_string(),
+            "com.hello.Example".to_string(),
+        ]),
+        JavaArgs {
+            cp: vec![".".to_string()],
+            errors: vec!["Unrecognized option: -hello-world".to_string()],
+            mode: ExecutionMode::Class {
+                class: "com.hello.Example".to_string(),
+                args: vec![],
+            },
+            props: vec![],
+            socket: "/var/run/landlord/landlordd.sock".to_string(),
+            version: false,
+        }
+    );
+}

--- a/landlord/src/bin/landlord.rs
+++ b/landlord/src/bin/landlord.rs
@@ -1,0 +1,105 @@
+extern crate landlord;
+
+use landlord::args::*;
+use landlord::bindings::*;
+use std::{env, process, str};
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc::*;
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+const USAGE: &'static str = "Usage: landlord [-options] class [args...]
+           (to execute a class)
+   or  landlord [-options] -jar jarfile [args...]
+           (to execute a jar file)
+where options include:
+    -cp <class search path of directories and zip/jar files> -classpath <class search path of directories and zip/jar files>
+                  A : separated list of directories, JAR archives,
+                  and ZIP archives to search for class files.
+    -D<name>=<value>
+                  set a system property
+    -version      print product version and exit
+    -showversion  print product version and continue
+    -? -help      print this help message
+    -socket       path to landlord UNIX domain socket";
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let parsed = parse_java_args(&args[1..].to_vec());
+
+    if parsed.version {
+        eprintln!("landlord version \"{}\"", VERSION);
+    }
+
+    if parsed.errors.is_empty() {
+        match parsed.mode {
+            ExecutionMode::Class {
+                ref class,
+                ref args,
+            } => {
+                let socket_path = parsed.socket.to_string();
+
+                match UnixStream::connect(socket_path.to_string()) {
+                    Err(ref mut e) => {
+                        eprintln!("landlord: failed to connect to socket: {:?}", e);
+
+                        process::exit(1);
+                    }
+
+                    Ok(mut stream) => {
+                        let (tx, rx) = channel();
+
+                        let result = install_fs_and_start(&parsed.cp, &parsed.props, class, args, &mut stream)
+                            .and_then(|pid| stream.try_clone().map(|stream_writer| (pid, stream_writer)))
+                            .and_then(|(pid, mut stream_writer)| {
+                                spawn_and_handle_signals(tx.clone());
+                                spawn_and_handle_stdin(tx.clone());
+                                spawn_and_handle_stream_read(stream, tx.clone());
+
+                                handle_events(pid, &mut stream_writer, rx, || {
+                                    UnixStream::connect(socket_path.to_string())
+                                })
+                            });
+
+                        let code = match result {
+                            Ok(c) => c,
+
+                            Err(e) => {
+                                eprintln!("landlord: {:?}", e);
+                                1
+                            }
+                        };
+
+                        process::exit(code);
+                    }
+                };
+            }
+
+            ExecutionMode::Exit { code } => {
+                process::exit(code);
+            }
+
+            ExecutionMode::Help { code } => {
+                eprintln!("{}", USAGE);
+
+                process::exit(code);
+            }
+
+            ExecutionMode::JarFile {
+                file: _file,
+                args: _args,
+            } => {
+                eprintln!("landlord: `-jar` currently unsupported");
+
+                process::exit(1);
+            }
+        }
+    } else {
+        parsed
+            .errors
+            .iter()
+            .for_each(|e| println!("landlord: {}", e));
+
+        process::exit(1);
+    }
+}

--- a/landlord/src/bindings.rs
+++ b/landlord/src/bindings.rs
@@ -252,10 +252,11 @@ pub fn install_fs_and_start(
     })
 }
 
-/// Tracks num bytes written to the provided `stream` and ensures
-/// that zero-padded blocks are written. Implemented because
-/// landlordd requires block size of 20, but the tar lib
-/// doesn't support that
+/// BlockSizeWritter ensures that data written to a provided `stream`
+/// is done in zero-padded blocks of the provided size. landlordd
+/// expects GNU-standard blocking factor of 20, so when writing tar
+/// data to it, `landlord` uses this wrapper with a `block_size` of
+/// 10240
 struct BlockSizeWriter<W: Write> {
     stream: Option<W>,
     written: usize,

--- a/landlord/src/bindings.rs
+++ b/landlord/src/bindings.rs
@@ -1,0 +1,310 @@
+use chan_signal::{notify, Signal};
+use libc;
+use proto::*;
+use std::{fs, io, net, path, process, thread};
+use std::io::prelude::*;
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc::*;
+use tar::Builder;
+
+/// Binds everything together and ensures that events received from a given `reader` will
+/// be handled accordingly.
+pub fn handle_events<NewS>(
+    pid: i32,
+    stream: &mut UnixStream,
+    reader: Receiver<Input>,
+    mut new_stream: NewS,
+) -> io::Result<i32>
+where
+    NewS: FnMut() -> io::Result<UnixStream>,
+{
+    let mut stdout = io::stdout();
+    let mut stderr = io::stderr();
+
+    let handler_reader = || {
+        reader
+            .recv()
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))
+    };
+    let handler_writer = |bs: Vec<u8>| {
+        if bs.is_empty() {
+            stream.shutdown(net::Shutdown::Write)
+        } else {
+            stream.write_all(&bs)
+        }
+
+    };
+    let session_writer = |bs: Vec<u8>| new_stream().and_then(|ref mut s| s.write_all(&bs));
+    let std_out = |bs: Vec<u8>| stdout.write_all(&bs);
+    let std_err = |bs: Vec<u8>| stderr.write_all(&bs);
+
+    input_handler(
+        pid,
+        handler_reader,
+        handler_writer,
+        session_writer,
+        std_out,
+        std_err,
+    )
+}
+
+/// Signals to the OS which signals we are interested in, and then
+/// spawns a thread to wait for them and forward them to the
+/// provided `sender`.
+pub fn spawn_and_handle_signals(sender: Sender<Input>) {
+    let all_signals = [
+        Signal::ABRT,
+        Signal::ALRM,
+        Signal::BUS,
+        Signal::CHLD,
+        Signal::CONT,
+        Signal::FPE,
+        Signal::HUP,
+        Signal::ILL,
+        Signal::INT,
+        Signal::IO,
+        Signal::KILL,
+        Signal::PIPE,
+        Signal::PROF,
+        Signal::QUIT,
+        Signal::SEGV,
+        Signal::STOP,
+        Signal::SYS,
+        Signal::TERM,
+        Signal::TRAP,
+        Signal::TSTP,
+        Signal::TTIN,
+        Signal::TTOU,
+        Signal::URG,
+        Signal::USR1,
+        Signal::USR2,
+        Signal::VTALRM,
+        Signal::WINCH,
+        Signal::XCPU,
+        Signal::XFSZ,
+    ];
+
+    // chan_signal doesn't have a public function for converting a signal to its integer code
+    // so we have to do that ourselves..
+
+    let as_sig = |s: &Signal| match *s {
+        Signal::HUP => libc::SIGHUP,
+        Signal::INT => libc::SIGINT,
+        Signal::QUIT => libc::SIGQUIT,
+        Signal::ILL => libc::SIGILL,
+        Signal::ABRT => libc::SIGABRT,
+        Signal::FPE => libc::SIGFPE,
+        Signal::KILL => libc::SIGKILL,
+        Signal::SEGV => libc::SIGSEGV,
+        Signal::PIPE => libc::SIGPIPE,
+        Signal::ALRM => libc::SIGALRM,
+        Signal::TERM => libc::SIGTERM,
+        Signal::USR1 => libc::SIGUSR1,
+        Signal::USR2 => libc::SIGUSR2,
+        Signal::CHLD => libc::SIGCHLD,
+        Signal::CONT => libc::SIGCONT,
+        Signal::STOP => libc::SIGSTOP,
+        Signal::TSTP => libc::SIGTSTP,
+        Signal::TTIN => libc::SIGTTIN,
+        Signal::TTOU => libc::SIGTTOU,
+        Signal::BUS => libc::SIGBUS,
+        Signal::PROF => libc::SIGPROF,
+        Signal::SYS => libc::SIGSYS,
+        Signal::TRAP => libc::SIGTRAP,
+        Signal::URG => libc::SIGURG,
+        Signal::VTALRM => libc::SIGVTALRM,
+        Signal::XCPU => libc::SIGXCPU,
+        Signal::XFSZ => libc::SIGXFSZ,
+        Signal::IO => libc::SIGIO,
+        Signal::WINCH => libc::SIGWINCH,
+        _ => 1,
+    };
+
+    let signal = notify(&all_signals);
+
+    thread::spawn(move || loop {
+        if let Some(s) = signal.recv() {
+            if let Err(e) = sender.send(Input::Signal(as_sig(&s))) {
+                eprintln!("landlord: signal handler crashed, {:?}", e);
+                return;
+            }
+        }
+    });
+}
+
+/// Spawns a thread and consumes stdin, forwarding a copy of
+/// the consumed data to provided `sender`
+pub fn spawn_and_handle_stdin(sender: Sender<Input>) {
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut stdin_lock = stdin.lock();
+        let mut buffer = vec![0; 1024];
+
+        loop {
+            let result = stdin_lock.read(&mut buffer).and_then(|num| {
+                buffer.truncate(num);
+
+                let (closed, message) = if num == 0 {
+                    (true, Input::StdInClosed)
+                } else {
+                    (false, Input::StdIn(buffer.clone()))
+                };
+
+                sender
+                    .send(message)
+                    .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, format!("{:?}", e)))
+                    .map(|_| closed)
+            });
+
+            match result {
+                Ok(closed) if closed => {
+                    return;
+                }
+                Ok(_) => (),
+                Err(ref err) if err.kind() == io::ErrorKind::Interrupted => (),
+                Err(e) => {
+                    eprintln!("landlord: stdin crashed, {:?}", e);
+                    return;
+                }
+            }
+        }
+    });
+}
+
+/// Spawns a thread and reads data from the provided `stream`. The actual logic
+/// of how much to read is done via the read_handler function.
+pub fn spawn_and_handle_stream_read(mut stream: UnixStream, sender: Sender<Input>) {
+    thread::spawn(move || {
+        let s = &mut stream;
+        let r = |n: usize| read_bytes(s, n);
+        let m = |msg: Input| {
+            sender
+                .send(msg)
+                .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))
+        };
+
+        if let Err(read_error) = read_handler(r, m) {
+            if let Err(_send_error) = sender.send(Input::Fail(read_error)) {
+                eprintln!("landlord: catastrophic failure (channel and read crashed)");
+                process::exit(1);
+            }
+        }
+    });
+}
+
+/// Writes the provided `class_path` to the provided `stream` and starts the process. Returns
+/// the process id (from landlordd's perpsective). Upon successful completion, the process
+/// is running and any data subsequently written to `stream` is stdin.
+pub fn install_fs_and_start(
+    class_path: &Vec<String>,
+    props: &Vec<(String, String)>,
+    class: &String,
+    args: &Vec<String>,
+    stream: &mut UnixStream,
+) -> io::Result<i32> {
+    // given a list of class path entries, these are written to the tar via their position in
+    // the vector. Meaning the first entry will be named "0", second "1", and so on. This
+    // allows the user to specify any combination of directories and files without us having
+    // to find some common parent path string.
+
+    let cp_with_names = class_path_with_names(&class_path);
+    let descriptor = app_cmdline(&cp_with_names, &props, &class, &args);
+
+    stream.write_all(descriptor.as_bytes()).and_then(|_| {
+        let tar_padding_stream = BlockSizeWriter::new(stream, 10240);
+
+        let mut tar_builder = Builder::new(tar_padding_stream);
+
+        cp_with_names
+            .iter()
+            .fold(Ok(()), |accum, &(ref path, ref name)| {
+                accum.and_then(|_| {
+                    fs::canonicalize(path).and_then(|path| {
+                        let path_struct = path::Path::new(&path);
+
+                        if path_struct.is_file() {
+                            fs::File::open(path_struct)
+                                .and_then(|ref mut f| tar_builder.append_file(name, f))
+                        } else if path_struct.is_dir() {
+                            tar_builder.append_dir_all(name, path.clone())
+                        } else {
+                            Ok(())
+                        }
+                    })
+                })
+            })
+            .and_then(|_| {
+                tar_builder
+                    .finish()
+                    .and(tar_builder.into_inner())
+                    .and_then(|ref mut stream| stream.finish())
+                    .and_then(|ref mut stream| match stream {
+                        &mut None => Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Unable to acquire stream (finish() called before?)",
+                        )),
+
+                        &mut Some(ref mut stream) => read_pid_handler(stream).ok_or(
+                            io::Error::new(io::ErrorKind::InvalidInput, "Unable to parse pid"),
+                        ),
+                    })
+            })
+    })
+}
+
+/// Tracks num bytes written to the provided `stream` and ensures
+/// that zero-padded blocks are written. Implemented because
+/// landlordd requires block size of 20, but the tar lib
+/// doesn't support that
+struct BlockSizeWriter<W: Write> {
+    stream: Option<W>,
+    written: usize,
+    block_size: usize,
+}
+
+impl<W: Write> Write for BlockSizeWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.stream {
+            None => Err(io::Error::new(io::ErrorKind::Other, "stream closed")),
+            Some(ref mut s) => match s.write(buf) {
+                Ok(size) => {
+                    self.written += size;
+
+                    Ok(size)
+                }
+
+                Err(err) => Err(err),
+            },
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.stream {
+            None => Err(io::Error::new(io::ErrorKind::Other, "stream closed")),
+            Some(ref mut s) => s.flush(),
+        }
+    }
+}
+
+impl<W: Write> BlockSizeWriter<W> {
+    pub fn new(obj: W, block_size: usize) -> BlockSizeWriter<W> {
+        BlockSizeWriter {
+            stream: Some(obj),
+            written: 0,
+            block_size,
+        }
+    }
+
+    pub fn finish(&mut self) -> io::Result<Option<W>> {
+        let operation = if let Some(ref mut stream) = self.stream {
+            let bytes_left = self.block_size - (self.written % self.block_size);
+            let bytes = vec![0; bytes_left];
+
+            stream.write_all(&bytes).and(stream.flush())
+        } else {
+            Ok(())
+        };
+
+        operation.map(|_| self.stream.take())
+    }
+}

--- a/landlord/src/lib.rs
+++ b/landlord/src/lib.rs
@@ -1,0 +1,8 @@
+extern crate byteorder;
+extern crate chan_signal;
+extern crate libc;
+extern crate tar;
+
+pub mod args;
+pub mod bindings;
+pub mod proto;

--- a/landlord/src/proto.rs
+++ b/landlord/src/proto.rs
@@ -1,0 +1,318 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io;
+use std::io::prelude::*;
+
+pub enum Input {
+    Exit(i32),
+    Fail(io::Error),
+    Signal(i32),
+    StdIn(Vec<u8>),
+    StdInClosed,
+    StdOut(Vec<u8>),
+    StdErr(Vec<u8>),
+}
+
+/// Allocates a buffer of `num` bytes and reads that exact number
+/// of bytes from `stream`
+pub fn read_bytes(read: &mut Read, num: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0; num];
+
+    read.read_exact(&mut buf).map(|_| buf)
+}
+
+/// core event loop that reads events from a provided reader and
+/// handles the events accordingly
+pub fn input_handler<R, W, SW, StdOut, StdErr>(
+    pid: i32,
+    mut reader: R,
+    mut writer: W,
+    mut single_session_writer: SW,
+    mut std_out: StdOut,
+    mut std_err: StdErr,
+) -> io::Result<i32>
+where
+    R: FnMut() -> io::Result<Input>,
+    W: FnMut(Vec<u8>) -> io::Result<()>,
+    StdOut: FnMut(Vec<u8>) -> io::Result<()>,
+    SW: FnMut(Vec<u8>) -> io::Result<()>,
+    StdErr: FnMut(Vec<u8>) -> io::Result<()>,
+{
+    loop {
+        match reader() {
+            Ok(Input::Exit(s)) => {
+                return Ok(s);
+            }
+
+            Ok(Input::Fail(e)) => {
+                return Err(e);
+            }
+
+            Ok(Input::StdIn(b)) => {
+                if !b.is_empty() {
+                    if let Err(e) = writer(b) {
+                        return Err(e);
+                    }
+                }
+            }
+
+            Ok(Input::StdInClosed) => {
+                if let Err(e) = writer(vec![]) {
+                    return Err(e);
+                }
+                /*
+                let result = encode_i32(pid)
+                    .and_then(|ref mut pid_bytes| {
+                        let mut data = vec![];
+
+                        data.push(b't');
+                        data.append(pid_bytes);
+
+                        single_session_writer(data)
+                    });
+
+                if let Err(e) = result {
+                    return Err(e);
+                }*/
+            }
+
+            Ok(Input::Signal(s)) => {
+                let result = encode_i32(pid)
+                    .and_then(|pid_bytes| encode_i32(s).map(|sig_bytes| (pid_bytes, sig_bytes)))
+                    .and_then(|(ref mut pid_bytes, ref mut sig_bytes)| {
+                        let mut data = vec![];
+
+                        data.push(b'k');
+                        data.append(pid_bytes);
+                        data.append(sig_bytes);
+
+                        single_session_writer(data)
+                    });
+
+                if let Err(e) = result {
+                    return Err(e);
+                }
+            }
+
+            Ok(Input::StdOut(b)) => {
+                if let Err(e) = std_out(b) {
+                    return Err(e);
+                }
+            }
+
+            Ok(Input::StdErr(b)) => {
+                if let Err(e) = std_err(b) {
+                    return Err(e);
+                }
+            }
+
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+}
+
+/// manages reading the socket (landlord protocol)
+pub fn read_handler<R, W>(mut reader: R, mut writer: W) -> io::Result<()>
+where
+    R: FnMut(usize) -> io::Result<Vec<u8>>,
+    W: FnMut(Input) -> io::Result<()>,
+{
+    loop {
+        match reader(1).map(|bs| bs[0]) {
+            Ok(101) => {
+                // UTF8 'e'
+                let result = read_payload(&mut reader)
+                    .map(|p| Input::StdErr(p))
+                    .and_then(|msg| writer(msg));
+
+                if result.is_err() {
+                    return result;
+                }
+            }
+            Ok(111) => {
+                // UTF8 'o'
+                let result = read_payload(&mut reader)
+                    .map(|p| Input::StdOut(p))
+                    .and_then(|msg| writer(msg));
+
+                if result.is_err() {
+                    return result;
+                }
+            }
+            Ok(120) => {
+                // UTF8 'x'
+
+                return reader(4)
+                    .and_then(|bs| decode_i32(&bs))
+                    .and_then(|code| writer(Input::Exit(code)));
+            }
+            Ok(other) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Unknown code: {}", other),
+                ))
+            }
+            Err(err) => {
+                return Err(err);
+            }
+        }
+    }
+}
+
+/// reads the process id from the provided `stream`
+pub fn read_pid_handler(stream: &mut Read) -> Option<i32> {
+    read_bytes(stream, 4)
+        .ok()
+        .and_then(|bs| io::Cursor::new(bs).read_i32::<BigEndian>().ok())
+}
+
+/// Creates the first line of data that is sent to landlordd when loading an app.
+pub fn app_cmdline(
+    class_path_with_names: &Vec<(String, String)>,
+    props: &Vec<(String, String)>,
+    class: &String,
+    args: &Vec<String>,
+) -> String {
+    let props = props
+        .iter()
+        .map(|&(ref n, ref v)| format!("-D{}={}", n, v))
+        .collect::<Vec<String>>()
+        .join("\u{0000}");
+
+    format!(
+        "l{}-cp\u{0000}{}\u{0000}{}{}\n",
+        if props == "" {
+            "".to_string()
+        } else {
+            format!("{}\u{0000}", props)
+        },
+        class_path_with_names
+            .iter()
+            .map(|ref e| e.1.to_string())
+            .collect::<Vec<String>>()
+            .join(":"),
+        class,
+        if args.is_empty() {
+            format!("")
+        } else {
+            format!("\u{0000}--\u{0000}{}", args.join("\u{0000}"))
+        }
+    )
+}
+
+/// Given class path entries, returns a new vector containing entries
+/// as a tuple, each element: (path, name to store in tar file)
+pub fn class_path_with_names(class_path: &Vec<String>) -> Vec<(String, String)> {
+    class_path
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.to_string(), format!("{}", i)))
+        .collect()
+}
+
+/// given a reader, reads a landlord payload, i.e. a 4-byte encoded (big endian) size followed
+/// by that number of bytes.
+fn read_payload<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: FnMut(usize) -> io::Result<Vec<u8>>,
+{
+    reader(4)
+        .and_then(|bs| decode_i32(&bs))
+        .and_then(|size| reader(size as usize))
+}
+
+fn decode_i32(vec: &Vec<u8>) -> io::Result<i32> {
+    io::Cursor::new(vec).read_i32::<BigEndian>()
+}
+
+fn encode_i32(value: i32) -> io::Result<Vec<u8>> {
+    let mut buf = vec![];
+
+    buf.write_i32::<BigEndian>(value).map(|_| buf)
+}
+
+#[test]
+fn test_app_cmdline_no_args() {
+    assert_eq!(
+        app_cmdline(
+            &vec![
+                ("/test1/one".to_string(), "0".to_string()),
+                ("/test1/two".to_string(), "1".to_string()),
+            ],
+            &vec![],
+            &"com.example.HelloWorld1".to_string(),
+            &vec![]
+        ),
+        "l-cp\u{0000}0:1\u{0000}com.example.HelloWorld1\n".to_string()
+    )
+}
+
+#[test]
+fn test_app_cmdline_with_args() {
+    assert_eq!(
+        app_cmdline(
+            &vec![
+                ("/test2/one".to_string(), "0".to_string()),
+                ("/test2/two".to_string(), "1".to_string()),
+            ],
+            &vec![],
+            &"com.example.HelloWorld2".to_string(),
+            &vec!["argone".to_string(), "arg two".to_string()]
+        ),
+        "l-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}--\u{0000}argone\u{0000}arg two\n"
+            .to_string()
+    )
+}
+
+#[test]
+fn test_app_cmdline_with_args_props() {
+    assert_eq!(
+        app_cmdline(
+            &vec![
+                ("/test2/one".to_string(), "0".to_string()),
+                ("/test2/two".to_string(), "1".to_string()),
+            ],
+            &vec![("one".to_string(), "#1!".to_string()), ("two".to_string(), "#2!".to_string())],
+            &"com.example.HelloWorld2".to_string(),
+            &vec!["argone".to_string(), "arg two".to_string()]
+        ),
+        "l-Done=#1!\u{0000}-Dtwo=#2!\u{0000}-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}--\u{0000}argone\u{0000}arg two\n"
+            .to_string()
+    )
+}
+
+#[test]
+fn test_class_path_with_names() {
+    assert_eq!(
+        class_path_with_names(&vec!["/test/one".to_string(), "/test/two".to_string()]),
+        vec![
+            ("/test/one".to_string(), "0".to_string()),
+            ("/test/two".to_string(), "1".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_decode_i32_invalid() {
+    assert!(decode_i32(&vec![]).is_err());
+    assert!(decode_i32(&vec![0]).is_err());
+    assert!(decode_i32(&vec![0, 0]).is_err());
+    assert!(decode_i32(&vec![0, 0, 0]).is_err());
+}
+
+#[test]
+fn test_decode_i32_valid() {
+    assert_eq!(decode_i32(&vec![0, 0, 0, 0]).ok(), Some(0));
+    assert_eq!(decode_i32(&vec![0, 0, 0, 1]).ok(), Some(1));
+    assert_eq!(decode_i32(&vec![1, 0, 0, 0]).ok(), Some(16777216));
+    assert_eq!(decode_i32(&vec![1, 0, 0, 1]).ok(), Some(16777217));
+}
+
+#[test]
+fn test_encode_i32_valid() {
+    assert_eq!(encode_i32(0).ok(), Some(vec![0, 0, 0, 0]));
+    assert_eq!(encode_i32(1).ok(), Some(vec![0, 0, 0, 1]));
+    assert_eq!(encode_i32(16777216).ok(), Some(vec![1, 0, 0, 0]));
+    assert_eq!(encode_i32(16777217).ok(), Some(vec![1, 0, 0, 1]));
+}

--- a/landlord/src/proto.rs
+++ b/landlord/src/proto.rs
@@ -196,7 +196,7 @@ pub fn app_cmdline(
         if args.is_empty() {
             format!("")
         } else {
-            format!("\u{0000}--\u{0000}{}", args.join("\u{0000}"))
+            format!("\u{0000}{}", args.join("\u{0000}"))
         }
     )
 }
@@ -260,7 +260,7 @@ fn test_app_cmdline_with_args() {
             &"com.example.HelloWorld2".to_string(),
             &vec!["argone".to_string(), "arg two".to_string()]
         ),
-        "l-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}--\u{0000}argone\u{0000}arg two\n"
+        "l-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}argone\u{0000}arg two\n"
             .to_string()
     )
 }
@@ -277,7 +277,7 @@ fn test_app_cmdline_with_args_props() {
             &"com.example.HelloWorld2".to_string(),
             &vec!["argone".to_string(), "arg two".to_string()]
         ),
-        "l-Done=#1!\u{0000}-Dtwo=#2!\u{0000}-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}--\u{0000}argone\u{0000}arg two\n"
+        "l-Done=#1!\u{0000}-Dtwo=#2!\u{0000}-cp\u{0000}0:1\u{0000}com.example.HelloWorld2\u{0000}argone\u{0000}arg two\n"
             .to_string()
     )
 }

--- a/landlord/src/proto.rs
+++ b/landlord/src/proto.rs
@@ -59,20 +59,6 @@ where
                 if let Err(e) = writer(vec![]) {
                     return Err(e);
                 }
-                /*
-                let result = encode_i32(pid)
-                    .and_then(|ref mut pid_bytes| {
-                        let mut data = vec![];
-
-                        data.push(b't');
-                        data.append(pid_bytes);
-
-                        single_session_writer(data)
-                    });
-
-                if let Err(e) = result {
-                    return Err(e);
-                }*/
             }
 
             Ok(Input::Signal(s)) => {

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -148,7 +148,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
                 val exitCodeBytes = byteStrings.last.result
                 assert(
                   processIdBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == processId &&
-                    outputBytes.utf8String == s"This is a test\nHello World #1\nHi #2\n${stdinStr}" &&
+                    outputBytes.utf8String == s"Argument #1: Hello World #1\nArgument #2: Hi #2\nThis is a test\n${stdinStr}" &&
                     exitCodeBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == 0)
               }
           }(ExecutionContext.Implicits.global) // We use this context to get us off the ScalaTest one (which would hang this)

--- a/landlordd/test/src/main/java/example/Count.java
+++ b/landlordd/test/src/main/java/example/Count.java
@@ -2,6 +2,12 @@ package example;
 
 import java.io.IOException;
 
+/**
+ * A test program that counts until it receives a signal, and
+ * then exits with the value of the signal it received (plus 128).
+ * Used to test that signals are being handled correctly when
+ * using `landlordd` and `landlord`.
+ */
 public class Count {
     private static volatile int exitCode = -1;
 
@@ -24,8 +30,6 @@ public class Count {
 
     @SuppressWarnings("unused")
     public static void trap(int signal) {
-        System.out.println("Trapped: " + signal);
-        if ((signal & 0xf) > 0)             // Terminate
-            exitCode = 128 + signal; // As per the convention of exit codes
+        exitCode = 128 + signal;
     }
 }

--- a/landlordd/test/src/main/java/example/Count.java
+++ b/landlordd/test/src/main/java/example/Count.java
@@ -1,0 +1,31 @@
+package example;
+
+import java.io.IOException;
+
+public class Count {
+    private static volatile int exitCode = -1;
+
+    public static void main(String[] args) throws IOException {
+        for (String arg: args) {
+            System.out.println(arg);
+        }
+
+        for (int i = 0; exitCode < 0; i++) {
+            System.out.println("Iteration #" + i);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                exitCode = 1;
+            }
+        }
+
+        System.exit(exitCode);
+    }
+
+    @SuppressWarnings("unused")
+    public static void trap(int signal) {
+        System.out.println("Trapped: " + signal);
+        if ((signal & 0xf) > 0)             // Terminate
+            exitCode = 128 + signal; // As per the convention of exit codes
+    }
+}

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -4,19 +4,21 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 
+/**
+ * A simple example showing the usage of arguments, properties, and stdin.
+ * When run with `landlordd` and `landlord`, it should behave as a drop-in
+ * replacement to the `java` command.
+ */
 public class Hello {
     public static void main(String[] args) throws IOException {
-        try {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> System.out.println("Shutdown trapped")));
-        } catch (SecurityException ignored) {
-            // An exception will be thrown when running via landlord started with --prevent-shutdown-hooks
-        }
-
-        System.out.println(System.getProperty("greeting", "No greeting was specified"));
+        int i = 0;
 
         for (String arg: args) {
-            System.out.println(arg);
+            i++;
+            System.out.println(String.format("Argument #%s: %s", i, arg));
         }
+
+        System.out.println(System.getProperty("greeting", "Welcome. Please type a message."));
 
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         String line = br.readLine();

--- a/landlordd/test/src/main/java/example/Shutdown.java
+++ b/landlordd/test/src/main/java/example/Shutdown.java
@@ -1,0 +1,26 @@
+package example;
+
+import java.io.IOException;
+
+/**
+ * An example used to demonstrate addShutdownHook behavior when running in
+ * landlordd.
+ */
+public class Shutdown {
+    public static void main(String[] args) throws IOException {
+        try {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> System.out.println("Shutdown trapped")));
+        } catch (SecurityException ignored) {
+            // An exception will be thrown when running via landlord started with --prevent-shutdown-hooks
+        }
+
+        System.exit(0);
+    }
+
+    @SuppressWarnings("unused")
+    public static void trap(int signal) {
+        System.out.println("Trapped: " + signal);
+        if ((signal & 0xf) > 0)             // Terminate
+          System.exit(128 + signal); // As per the convention of exit codes
+    }
+}

--- a/scripts/integration-test-cli
+++ b/scripts/integration-test-cli
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Builds the CLI and daemon and runs a small integration test
+
+DIR=/tmp/landlord-test
+
+cleanup() {
+    rm -rf "$DIR"
+}
+
+trap cleanup EXIT
+
+# Normalize dirs
+SCRIPT_NAME="${BASH_SOURCE[0]}"
+if [ -h "$SCRIPT_NAME" ]; then
+    SCRIPT_NAME="$(readlink "$SCRIPT_NAME")"
+fi
+ROOT_DIR="$(cd "$(dirname "$SCRIPT_NAME")" && cd .. && pwd)"
+cd "$ROOT_DIR"
+
+# Build projects
+(cd landlord && cargo build --release)
+(cd landlordd && sbt daemon/stage)
+
+# TODO remove the line below once alpakka #882, landlord #27, landlord #28 merged
+exit 0
+
+# Start landlordd
+rm -rf "$DIR"
+mkdir -p "$DIR"
+landlordd/daemon/target/universal/stage/bin/landlordd --bind-dir-path "$DIR" --prevent-shutdown-hooks &
+LANDLORDD_PID="$!"
+
+while ! [ -e "$DIR/landlordd.sock" ]; do
+    sleep 1
+done
+
+# Run a program that uses stdin and properties
+OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+EXPECTED='hello world
+Testing'
+
+# Shutdown landlordd
+kill "$LANDLORDD_PID"
+wait
+
+# Test that we got what we expected
+[ "$OUTPUT" = "$EXPECTED" ]


### PR DESCRIPTION
This implements `landlord`, the CLI client for `landlordd`.

### Getting Started
You'll need `landlordd` built with the following PRs:

* https://github.com/huntc/landlord/pull/27
* https://github.com/akka/alpakka/pull/882

### Notes

* integration test has been written, but isn't enabled until we have releases of alpakka and the other landlord PRs merged

### TODO
- [x] argument parsing
- [x] signal handling
- [x] stdin handling
- [x] stdout/stderr handling
- [x] Travis CI for CLI
- [x] some unit tests
- [x] integration tests? perhaps a single basic one for now
- [x] handle stdin end of stream condition
- [x] give double `System.exit()` some thought, and the race condition around removing `SecurityManager`
