### PR TITLE
Use null character as argument separator

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -196,7 +196,7 @@ class JvmExecutor(
   def starting(unstopped: Boolean): Receive = {
     case StartProcess(commandLine, stdinSource) if unstopped =>
       val errCapture = new BoundedByteArrayOutputStream
-      val commandLineArgs = commandLine.split(" ")
+      val commandLineArgs = commandLine.split("\u0000")
       Console.withErr(errCapture) {
         val (parseArgs, mainArgs) = splitMainArgs(commandLineArgs)
         parser.parse(parseArgs, JavaConfig(mainArgs = mainArgs))

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
@@ -32,12 +32,15 @@ object ProcessParameterParser {
  *
  * The stream is presented as follows:
  *
- * 1. The first line (up until a LF) are the command line args to pass to the `java` command.
- *    The arguments are decoded as UTF-8. Note that any non-JVM options that are to be passed to the
- *    program itself should follow a "--" option e.g.:
- *      -cp some.jar example.Hello -- -b http://127.0.0.1:8080/conn
+ * 1. The first line (up until a LF) are the command line args to pass to the `java` command. Arguments
+ *    are separated by a null byte, i.e. \u0000 in UTF-8. The arguments are decoded as UTF-8. Note
+ *    that any non-JVM options that are to be passed to the program itself should follow a "--" option.
+ *
+ *    Full example: -cp\u0000some.jar\u0000example.Hello\u0000--\u0000-b\u0000http://127.0.0.1:8080/conn
+ *
  * 2. The next line represents the binary tar file output of the file system that the `java`
  *    command and its host program will ultimately read from e.g. containing the class files.
+ *
  * 3. The stream then represents stdin until the stream is completed. The input is decoded as UTF-8.
  *
  */

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -87,7 +87,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
 
       val processId = 123
 
-      val cl = "-cp classes example.Hello"
+      val cl = "-cp\u0000classes\u0000example.Hello\u0000Hello World #1\u0000Hi #2"
 
       val TarBlockSize = 10240
       val tar = {
@@ -176,7 +176,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
                 val exitCodeBytes = byteStrings.last.result
                 assert(
                   processIdBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == processId &&
-                    outputBytes.utf8String == stdinStr &&
+                    outputBytes.utf8String == s"Hello World #1\nHi #2\n${stdinStr}" &&
                     exitCodeBytes.iterator.getInt(ByteOrder.BIG_ENDIAN) == 0)
               }
           }(ExecutionContext.Implicits.global) // We use this context to get us off the ScalaTest one (which would hang this)

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -12,6 +12,10 @@ public class Hello {
             // An exception will be thrown when running via landlord started with --prevent-shutdown-hooks
         }
 
+        for (String arg: args) {
+            System.out.println(arg);
+        }
+
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         String line = br.readLine();
         if (line != null) System.out.println(line);


### PR DESCRIPTION
Modifies the command line separator to be `\0` so that whitespace is handled correctly. Fixes #20 