### PR TITLE
Fix bug in ExitEarly handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 *.log
+*.log.gz

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -351,10 +351,14 @@ class JvmExecutor(
     case ExitEarly(exitStatus, errorMessage) =>
       out.success(
         Source
-          .single {
-            errorMessage.fold(processIdToBytes(processId))(e => StderrPrefix ++ ByteString(e)) ++
+          .single(
+            processIdToBytes(processId) ++
+              errorMessage.fold(ByteString.empty) { e =>
+                val errorBytes = ByteString(e)
+                StderrPrefix ++ sizeToBytes(errorBytes.length) ++ errorBytes
+              } ++
               exitStatusToBytes(exitStatus)
-          }
+          )
           .watchTermination()(stopSelfWhenDone)
       )
   }


### PR DESCRIPTION
Fix a small bug in `JvmExecutor` where it handles `ExitEarly`, notably fixing these issues:

1) if an error message was provided, pid would never be sent over the wire
2) if an error message was provided, it was sent over the wire without the `sizeToBytes`, so client wouldn't know how much data to read