### PR TITLE
Implement support for specifying properties (-D...)

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JavaArgs.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JavaArgs.scala
@@ -1,0 +1,68 @@
+package com.github.huntc.landlord
+
+import scala.collection.immutable.Seq
+
+sealed trait ExecutionMode
+
+case class ClassExecutionMode(`class`: String, args: Seq[String]) extends ExecutionMode
+
+case class JavaArgs(
+    cp: Seq[String],
+    errors: Seq[String],
+    mode: ExecutionMode,
+    props: Seq[(String, String)])
+
+/**
+ * Parses arguments in a similar manner to the JRE's `java` command. Due to some
+ * strange argument conventions, this is hand-rolled. For instance, supporting
+ * the `-Dname=value` syntax is not possible with scopt.
+ */
+object JavaArgs {
+  def parse(args: Seq[String]): Either[Seq[String], JavaArgs] = {
+    @annotation.tailrec
+    def step(as: Seq[String], accum: JavaArgs): JavaArgs =
+      as.headOption match {
+        case Some(entry) if !entry.startsWith("-") =>
+          accum.copy(mode = ClassExecutionMode(entry, as.tail))
+
+        case Some(flag) if flag == "-cp" || flag == "-classpath" =>
+          step(
+            if (as.tail.isEmpty) Seq.empty else as.tail.tail,
+            as.tail.headOption.fold(accum.copy(errors = accum.errors :+ s"$flag requires class path specification")) { cp =>
+              accum.copy(cp = cp.split(":").toVector)
+            }
+          )
+
+        case Some(flag) if flag.startsWith("-D") =>
+          val parts =
+            flag
+              .drop(2)
+              .split("=", 2)
+
+          step(
+            as.tail,
+            if (parts.length == 2)
+              accum.copy(props = accum.props :+ (parts(0) -> parts(1)))
+            else
+              accum
+          )
+
+        case Some(flag) =>
+          step(
+            as.tail,
+            accum.copy(errors = accum.errors :+ s"Unrecognized option: $flag")
+          )
+
+        case None =>
+          accum
+      }
+
+    val parsed =
+      step(args, JavaArgs(Seq.empty, Seq.empty, ClassExecutionMode("", Seq.empty), Seq.empty))
+
+    if (parsed.errors.isEmpty)
+      Right(parsed)
+    else
+      Left(parsed.errors)
+  }
+}

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/ProcessParameterParser.scala
@@ -34,9 +34,10 @@ object ProcessParameterParser {
  *
  * 1. The first line (up until a LF) are the command line args to pass to the `java` command. Arguments
  *    are separated by a null byte, i.e. \u0000 in UTF-8. The arguments are decoded as UTF-8. Note
- *    that any non-JVM options that are to be passed to the program itself should follow a "--" option.
+ *    that any non-JVM options that are to be passed to the program itself should follow a class name
+ *    argument (which doesn't begin with a dash), per the `java` command's format.
  *
- *    Full example: -cp\u0000some.jar\u0000example.Hello\u0000--\u0000-b\u0000http://127.0.0.1:8080/conn
+ *    Full example: -cp\u0000some.jar\u0000example.Hello\u0000-b\u0000http://127.0.0.1:8080/conn
  *
  * 2. The next line represents the binary tar file output of the file system that the `java`
  *    command and its host program will ultimately read from e.g. containing the class files.

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JavaArgsSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JavaArgsSpec.scala
@@ -1,0 +1,38 @@
+package com.github.huntc.landlord
+
+import org.scalatest._
+import scala.collection.immutable.Seq
+
+class JavaArgsSpec extends WordSpec with Matchers {
+  "parse" should {
+    "Accept just two regular classpath arg and the main class" in {
+      val parsed = JavaArgs.parse(Seq("-cp", "somepath:someotherpath", "mainclass"))
+      assert(parsed.contains(JavaArgs(Seq("somepath", "someotherpath"), Seq.empty, ClassExecutionMode("mainclass", Seq.empty), Seq.empty)))
+    }
+
+    "Accept just a glob classpath arg and the main class" in {
+      val parsed = JavaArgs.parse(List("-cp", "lib/*", "mainclass"))
+      assert(parsed.contains(JavaArgs(Seq("lib/*"), Seq.empty, ClassExecutionMode("mainclass", Seq.empty), Seq.empty)))
+    }
+
+    "Return just the main class when no args" in {
+      val parsed = JavaArgs.parse(List("mainclass"))
+      assert(parsed.contains(JavaArgs(Seq.empty, Seq.empty, ClassExecutionMode("mainclass", Seq.empty), Seq.empty)))
+    }
+
+    "Return the main class and args" in {
+      val parsed = JavaArgs.parse(List("mainclass", "mainarg0", "mainarg1"))
+      assert(parsed.contains(JavaArgs(Seq.empty, Seq.empty, ClassExecutionMode("mainclass", Seq("mainarg0", "mainarg1")), Seq.empty)))
+    }
+
+    "Parse properties" in {
+      val parsed = JavaArgs.parse(List("-Dtest1=one", "-Dtest2=two", "mainclass"))
+      assert(parsed.contains(JavaArgs(Seq.empty, Seq.empty, ClassExecutionMode("mainclass", Seq.empty), Seq("test1" -> "one", "test2" -> "two"))))
+    }
+
+    "Fail when given invalid flags" in {
+      val parsed = JavaArgs.parse(List("-what", "mainclass"))
+      assert(parsed.left.exists(_ == Seq("Unrecognized option: -what")))
+    }
+  }
+}

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -12,6 +12,8 @@ public class Hello {
             // An exception will be thrown when running via landlord started with --prevent-shutdown-hooks
         }
 
+        System.out.println(System.getProperty("greeting", "No greeting was specified"));
+
         for (String arg: args) {
             System.out.println(arg);
         }


### PR DESCRIPTION
This implements support for properties.

Implementation note: I reimplemented the command line parser as scopt can't (at least, I can't discern any way to make it do it) parse the typical java args, e.g. `-Dname=value`.

This also puts us in a good position to easily implement `-jar` support via adding a new `ExecutionMode`.

Fixes #23