### PR TITLE
Update bash client to use null bytes

### DIFF
--- a/landlordd/client.sh
+++ b/landlordd/client.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ( \
   printf "l" && \
-  echo "-cp classes example.Hello" && \
+  printf -- $"l-cp\0classes\0example.Hello\n" && \
   tar -c -C $(pwd)/test/target/scala-2.12 classes && \
   cat <&0 \
   ) | \


### PR DESCRIPTION
Oops - I forgot to update `client.sh` in #22 when spaces were changed to a null byte. This fixes that.