### PR TITLE
Fix a crash when attempting to load unsupported class files

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -359,6 +359,9 @@ class JvmExecutor(
 
             context.become(started(cls, processThreadGroup, exitStatusPromise))
           } catch {
+            case e: UnsupportedClassVersionError =>
+              classLoader.close()
+              self ! ExitEarly(1, Some(if (e.getCause != null) e.getCause.toString else e.toString))
             case NonFatal(e) =>
               classLoader.close()
               self ! ExitEarly(1, Some(if (e.getCause != null) e.getCause.toString else e.toString))


### PR DESCRIPTION
Running an incompatible class file would crash `landlordd` because we were only catching `NonFatal`, of which `UnsupportedClassVersionError` is not (since it derives from `LinkageError`, which isn't considered `NonFatal` ... even though it probably should be, but that's another topic of discussion I suppose)

Fixes #26

Here's output from the client with this fix in place:

```
~/work/farmco/landlord#fix-crash $ landlord/target/release/landlord -cp landlordd/test/target/scala-2.12/classes example.Count
java.lang.UnsupportedClassVersionError: example/Count has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0-> 1
``` 

See:

https://docs.oracle.com/javase/7/docs/api/java/lang/UnsupportedClassVersionError.html
https://github.com/scala/scala/blob/v2.12.3/src/library/scala/util/control/NonFatal.scala#L1


