### PR TITLE
Fix scopt usage to exit 1 if error. Also adds --version and --help flags

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -31,6 +31,8 @@ object Main extends App {
   val parser = new scopt.OptionParser[Config](Version.executableScriptName) {
     head(Version.executableScriptName, Version.current)
     note("Daemon for sharing JVM memory between JVM processes - used with a client as a substitute for the `java` command")
+    help("help").text("prints this usage text")
+    version("version").text("prints version text")
 
     opt[String]("bind-dir-path").action { (x, c) =>
       c.copy(bindDirPath = Paths.get(x))
@@ -253,6 +255,7 @@ object Main extends App {
         }
 
     case None =>
-    // arguments are bad, error message will have been displayed
+      // arguments are bad, error message will have been displayed
+      sys.exit(1)
   }
 }


### PR DESCRIPTION
Small fix for scopt usage -- now a validation error results in a non-zero exit code. Prior to this, for example, an unwritable UNIX domain socket would exit 0 and print the help.

Here's some usage with this PR (note the exit codes):

```bash
$ ./daemon/target/universal/stage/bin/landlordd --help
landlordd 0.1.0-SNAPSHOT
Usage: landlordd [options]

Daemon for sharing JVM memory between JVM processes - used with a client as a substitute for the `java` command
  --help                   prints this usage text
  --version                prints version text
  --bind-dir-path <value>  The Unix Domain Socket path to listen on.
  --exit-timeout <value>   The time to wait for a process to exit before interrupting. Defaults to 12 seconds (12s).
  --prevent-shutdown-hooks
                           When set, a security exception will be thrown if shutdown hooks are detected within a process. Defaults to false, which then just warns on stderr.
  --output-drain-time-at-exit <value>
                           The amount of time to wait for a process to have its stdout/stderr transmitted at exit. Defaults to 100 milliseconds (500ms).
  --process-dir-path <value>
                           The path to use for the working directory for the process.
  --stdin-timeout <value>  The maximum amount of time to block waiting on stdin. Defaults to 1 hour (1h).
  --use-default-security-manager <value>
                           When true, the JVM's default security manager will be used for processes. The option defaults to false.
-> 0
```

```bash
$ ./daemon/target/universal/stage/bin/landlordd --version
landlordd 0.1.0-SNAPSHOT
-> 0
```

```bash
$ ./daemon/target/universal/stage/bin/landlordd
Error: Unix socket directory must exist with write permission: /var/run/landlord
Try --help for more information.
-> 1
```