### PR TITLE
Call Thread.interrupt() when shutting down

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -258,7 +258,11 @@ class JvmExecutor(
 
                             group.enumerate(threadsInGroup)
 
-                            threadsInGroup.filterNot(_ == currentThread)
+                            threadsInGroup.filterNot(t => t == null || t == currentThread)
+                          }
+
+                          activeThreads().foreach { thread =>
+                            thread.interrupt()
                           }
 
                           @annotation.tailrec

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -11,6 +11,20 @@ import java.io.IOException;
  */
 public class Hello {
     public static void main(String[] args) throws IOException {
+        // Landlord will call interrupt on the threads of programs it manages so
+        // that they can cooperatively terminate. We help test this by launching
+        // a thread that doesn't terminate until it has been interrupted.
+
+        new Thread(() -> {
+            while (!Thread.interrupted()) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        }).start();
+
         int i = 0;
 
         for (String arg: args) {


### PR DESCRIPTION
Calls `Thread.interrupt()` when waiting for threads to exit. I think this fits well with the design of landlord as it is effectively cooperative multi-tenancy. We of course can't guarantee that programs will check if their threads are interrupted, but this provides a mechanism for them to do so. For event loop style applications, they should check `Thread.isInterrupted()` on occasion.