### PR TITLE
Initialize java.util.logging.LogManager in landlordd

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -14,6 +14,7 @@ import java.nio.file.{ Files, Path, Paths }
 import java.security.Permission
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.LogManager
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ Future, Promise }
@@ -126,6 +127,11 @@ class JvmExecutor(
     exitTimeout: FiniteDuration, outputDrainTimeAtExit: FiniteDuration,
     processDirPath: Path
 ) extends Actor with ActorLogging with Timers {
+
+  // java.util.logging.LogManager has a hard-coded addShutdownHook. By loading the
+  // class now we prevent any child processes from registering one themselves.
+
+  LogManager.getLogManager
 
   import JvmExecutor._
 


### PR DESCRIPTION
So - this is the last change to run our apps without any warnings about shutdown hooks. It's a minor hack and I'm not sure we'll merge it, but in the interest of discussion here's the PR.

For context, here's the `addShutdownHook` in the JDK source:

https://github.com/bpupadhyaya/openjdk-8/blob/master/jdk/src/share/classes/java/util/logging/LogManager.java#L258

For us, our use of Caffeine for caching is the culprit here as it uses `java.util.logging`. There's no configuration for this.

By calling `LogManager.getLogManager` in landlord, we can play nicer with applications that use `java.util.Logging` as the shutdown hook will be registered in the context of landlord.

It feels like a better solution would be to somehow provide our own `java.lang.Runtime` implementation that would allow shutdown hooks to work in the context of landlord, but I don't know if that's possible and haven't looked into it yet.

Either way, this was verified to work and I have our apps working with `--prevent-shutdown-hooks`.