### PR TITLE
Add support for TCP to the client

### DIFF
--- a/landlord/src/bin/landlord.rs
+++ b/landlord/src/bin/landlord.rs
@@ -2,7 +2,9 @@ extern crate landlord;
 
 use landlord::args::*;
 use landlord::bindings::*;
-use std::{env, process, str};
+use std::{env, io, process, str};
+use std::io::prelude::*;
+use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::sync::mpsc::*;
 
@@ -21,7 +23,7 @@ where options include:
     -version      print product version and exit
     -showversion  print product version and continue
     -? -help      print this help message
-    -socket       path to landlord UNIX domain socket";
+    -socket       socket to connect to. available schemes: \"unix\", \"tcp\"";
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -37,42 +39,15 @@ fn main() {
                 ref class,
                 ref args,
             } => {
-                let socket_path = parsed.socket.to_string();
-
-                match UnixStream::connect(socket_path.to_string()) {
-                    Err(ref mut e) => {
-                        eprintln!("landlord: failed to connect to socket: {:?}", e);
-
-                        process::exit(1);
+                match parsed.socket {
+                    Socket::Unix(path)   => {
+                        handle_execute_class(&parsed.cp, class, args, &parsed.props, || UnixStream::connect(&path))
                     }
 
-                    Ok(mut stream) => {
-                        let (tx, rx) = channel();
-
-                        let result = install_fs_and_start(&parsed.cp, &parsed.props, class, args, &mut stream)
-                            .and_then(|pid| stream.try_clone().map(|stream_writer| (pid, stream_writer)))
-                            .and_then(|(pid, mut stream_writer)| {
-                                spawn_and_handle_signals(tx.clone());
-                                spawn_and_handle_stdin(tx.clone());
-                                spawn_and_handle_stream_read(stream, tx.clone());
-
-                                handle_events(pid, &mut stream_writer, rx, || {
-                                    UnixStream::connect(socket_path.to_string())
-                                })
-                            });
-
-                        let code = match result {
-                            Ok(c) => c,
-
-                            Err(e) => {
-                                eprintln!("landlord: {:?}", e);
-                                1
-                            }
-                        };
-
-                        process::exit(code);
+                    Socket::Tcp(address) => {
+                        handle_execute_class(&parsed.cp, class, args, &parsed.props, || TcpStream::connect(&address))
                     }
-                };
+                }
             }
 
             ExecutionMode::Exit { code } => {
@@ -101,5 +76,44 @@ fn main() {
             .for_each(|e| println!("landlord: {}", e));
 
         process::exit(1);
+    }
+}
+
+fn handle_execute_class<IO, NewS>(cp: &Vec<String>, class: &String, args: &Vec<String>, props: &Vec<(String, String)>, mut new_socket: NewS)
+where
+    IO: IOSocket + Read + Send + Write + 'static,
+    NewS: FnMut() -> io::Result<IO> {
+
+    match new_socket() {
+        Err(ref mut e) => {
+            eprintln!("landlord: failed to connect to socket: {:?}", e);
+
+            process::exit(1);
+        }
+
+        Ok(mut stream) => {
+            let (tx, rx) = channel();
+
+            let result = install_fs_and_start(&cp, &props, class, args, &mut stream)
+                .and_then(|pid| stream.try_clone().map(|stream_writer| (pid, stream_writer)))
+                .and_then(|(pid, mut stream_writer)| {
+                    spawn_and_handle_signals(tx.clone());
+                    spawn_and_handle_stdin(tx.clone());
+                    spawn_and_handle_stream_read(stream, tx.clone());
+
+                    handle_events(pid, &mut stream_writer, rx, new_socket)
+                });
+
+            let code = match result {
+                Ok(c) => c,
+
+                Err(e) => {
+                    eprintln!("landlord: {:?}", e);
+                    1
+                }
+            };
+
+            process::exit(code);
+        }
     }
 }

--- a/scripts/integration-test-cli
+++ b/scripts/integration-test-cli
@@ -39,9 +39,9 @@ SOCAT_PID="$!"
 while ! nc -z 127.0.0.1 2375; do sleep 1; done
 
 # Run a program that uses stdin and properties
-OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -H "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
 # Run the same program again, but this time over TCP
-OUTPUT2=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "tcp://127.0.0.1:2375" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+OUTPUT2=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -H "tcp://127.0.0.1:2375" -cp landlordd/test/target/scala-2.12/classes example.Hello)
 EXPECTED='hello world
 Testing
 Good Bye!'

--- a/scripts/integration-test-cli
+++ b/scripts/integration-test-cli
@@ -2,7 +2,8 @@
 
 set -e
 
-# Builds the CLI and daemon and runs a small integration test
+# Builds the CLI and daemon and runs a small integration test, testing connectivity
+# over TCP and Unix Domain Sockets.
 
 DIR=/tmp/landlord-test
 
@@ -30,20 +31,29 @@ rm -rf "$DIR"
 mkdir -p "$DIR"
 landlordd/daemon/target/universal/stage/bin/landlordd --bind-dir-path "$DIR" &
 LANDLORDD_PID="$!"
+while ! [ -e "$DIR/landlordd.sock" ]; do sleep 1; done
 
-while ! [ -e "$DIR/landlordd.sock" ]; do
-    sleep 1
-done
+# Setup socat for forwarding connections on TCP port 2375 to the unix domain socket (temporary until landlordd has TCP support)
+socat -d -d TCP4-LISTEN:2375,fork "UNIX-CONNECT:$DIR/landlordd.sock" &
+SOCAT_PID="$!"
+while ! nc -z 127.0.0.1 2375; do sleep 1; done
 
 # Run a program that uses stdin and properties
-OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+# Run the same program again, but this time over TCP
+OUTPUT2=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "tcp://127.0.0.1:2375" -cp landlordd/test/target/scala-2.12/classes example.Hello)
 EXPECTED='hello world
 Testing
 Good Bye!'
 
-# Shutdown landlordd
+# Shutdown landlordd and socat
 kill "$LANDLORDD_PID"
+kill "$SOCAT_PID"
 wait
 
 # Test that we got what we expected
-[ "$OUTPUT" = "$EXPECTED" ]
+EXPECTED='hello world
+Testing
+Good Bye!'
+
+[ "$OUTPUT" = "$EXPECTED" ] && [ "$OUTPUT2" = "$EXPECTED" ]


### PR DESCRIPTION
Adds support for TCP to the client. Integration test uses socat for now to test TCP, until TCP lands in the server component.

There's two commits here: The first adds the TCP support. The second cleans up a few things with vec/slice/str usage to be more idiomatic, and runs `cargo fmt` on the source.