### PR TITLE
A process was not shutdown upon losing a connection

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -232,8 +232,7 @@ class JvmExecutor(
         throw e
     }
     .andThen {
-      case _ =>
-        self ! ConnectionReadClosed
+      case _ => self ! ConnectionReadClosed
     }
 
   def receive: Receive =
@@ -351,7 +350,7 @@ class JvmExecutor(
 
                           @annotation.tailrec
                           def waitForTermination(): Unit =
-                            activeThreads(group).filterNot(_.getName.startsWith(context.system.name)).headOption match {
+                            activeThreads(group).find(!_.getName.startsWith(context.system.name)) match {
                               case Some(h) =>
                                 try {
                                   h.join()

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -28,6 +28,7 @@ object JvmExecutor {
     stdin: ThreadGroupInputStream, stdinTimeout: FiniteDuration, stdout: ThreadGroupPrintStream, stderr: ThreadGroupPrintStream,
     in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]],
     exitTimeout: FiniteDuration, outputDrainTimeAtExit: FiniteDuration,
+    heatbeatInterval: FiniteDuration,
     processDirPath: Path
   ): Props =
     Props(
@@ -37,13 +38,15 @@ object JvmExecutor {
         stdin, stdinTimeout, stdout, stderr,
         in, out,
         exitTimeout, outputDrainTimeAtExit,
+        heatbeatInterval,
         processDirPath
       )
     )
 
   case class StartProcess(commandLine: String, stdin: Source[ByteString, AnyRef])
   case class SignalProcess(signal: Int)
-  case object SignalProcessEot
+  private case object ConnectionReadClosed
+  private case object ConnectionWriteClosed
   private case object Stop
 
   private[landlord] class BoundedByteArrayOutputStream extends ByteArrayOutputStream {
@@ -98,15 +101,14 @@ object JvmExecutor {
 
   /**
    * Determines all of the active threads that are (recursively) a member of
-   * a thread group. Threads that belong to Landlord itself are filtered out
-   * from the result.
+   * a thread group.
    */
   private[landlord] def activeThreads(group: ThreadGroup): Set[Thread] =
     Thread
       .getAllStackTraces
       .keySet
       .asScala
-      .filter(t => memberOfThreadGroup(t.getThreadGroup, group) && !t.getName.startsWith("landlord-"))
+      .filter(t => memberOfThreadGroup(t.getThreadGroup, group))
       .toSet
 
   /**
@@ -192,6 +194,7 @@ class JvmExecutor(
     stdin: ThreadGroupInputStream, stdinTimeout: FiniteDuration, stdout: ThreadGroupPrintStream, stderr: ThreadGroupPrintStream,
     in: Source[ByteString, NotUsed], out: Promise[Source[ByteString, NotUsed]],
     exitTimeout: FiniteDuration, outputDrainTimeAtExit: FiniteDuration,
+    heatbeatInterval: FiniteDuration,
     processDirPath: Path
 ) extends Actor with ActorLogging with Timers {
 
@@ -199,11 +202,6 @@ class JvmExecutor(
 
   implicit val mat: ActorMaterializer = ActorMaterializer()
   import context.dispatcher
-
-  def stopSelfWhenDone(mat: NotUsed, done: Future[akka.Done]): NotUsed = {
-    done.map(_ => Stop).pipeTo(self)
-    NotUsed
-  }
 
   log.debug("Process actor starting for {}", processId)
   in
@@ -235,8 +233,7 @@ class JvmExecutor(
     }
     .andThen {
       case _ =>
-        self ! SignalProcessEot
-        self ! SignalProcess(SIGINT)
+        self ! ConnectionReadClosed
     }
 
   def receive: Receive =
@@ -322,6 +319,7 @@ class JvmExecutor(
                           stdin.signalClose()
 
                           activeThreads(group)
+                            .filterNot(_.getName.startsWith(context.system.name))
                             .foreach { thread =>
                               thread.interrupt()
                             }
@@ -339,6 +337,12 @@ class JvmExecutor(
                               log.warning("Unable to access shutdown hooks; they will not be run until the JVM exits")
                           }
 
+                          // A couple notes on threads:
+                          // 1) We rely on a convention that Akka follows for naming its threads, that is
+                          //    they start with "${ActorSystemName}-"
+                          // 2) If this convention changes, we may be waiting on threads that our our own
+                          //    (i.e. belong to landlordd) and the process will never exit.
+
                           // A couple notes on shutdown hooks:
                           // 1) We don't interrupt shutdown hook threads -- this behavior is
                           // consistent with the JVM which doesn't interrupt them either.
@@ -347,7 +351,7 @@ class JvmExecutor(
 
                           @annotation.tailrec
                           def waitForTermination(): Unit =
-                            activeThreads(group).headOption match {
+                            activeThreads(group).filterNot(_.getName.startsWith(context.system.name)).headOption match {
                               case Some(h) =>
                                 try {
                                   h.join()
@@ -377,7 +381,7 @@ class JvmExecutor(
                           properties.destroy()
                           securityManager.destroy()
 
-                        }, "landlord-cleanup").start()
+                        }, s"${context.system.name}-cleanup").start()
                       }
                     case None =>
                       self ! SignalProcess(SIGABRT)
@@ -424,6 +428,7 @@ class JvmExecutor(
                   stdoutSource
                     .map(bytes => StdoutPrefix ++ sizeToBytes(bytes.size) ++ bytes)
                     .merge(stderrSource.map(bytes => StderrPrefix ++ sizeToBytes(bytes.size) ++ bytes))
+                    .keepAlive(heatbeatInterval, () => StdoutPrefix ++ sizeToBytes(0))
                     .concat(
                       Source.fromFuture(
                         exitStatusPromise
@@ -432,7 +437,14 @@ class JvmExecutor(
                       )
                     )
                 )
-                .watchTermination()(stopSelfWhenDone)
+                .watchTermination() {
+                  case (m, done) =>
+                    done.onComplete { _ =>
+                      self ! ConnectionWriteClosed
+                    }
+
+                    m
+                }
             )
 
             processThread.setContextClassLoader(classLoader)
@@ -468,14 +480,21 @@ class JvmExecutor(
               } ++
               exitStatusToBytes(exitStatus)
           )
-          .watchTermination()(stopSelfWhenDone)
+          .watchTermination() {
+            case (m, done) =>
+              done.onComplete { _ =>
+                self ! Stop
+              }
+
+              m
+          }
       )
   }
 
   def started(mainClass: Class[_], processThreadGroup: ThreadGroup, stopInProgress: AtomicBoolean): Receive = {
     case SignalProcess(signal) =>
-      try {
-        if (!stopInProgress.get && !processThreadGroup.isDestroyed) { // Best effort
+      if (!stopInProgress.get && !processThreadGroup.isDestroyed) { // Best effort
+        try {
           new Thread(
             processThreadGroup, { () =>
             try {
@@ -484,26 +503,33 @@ class JvmExecutor(
             } catch {
               case _: NoSuchMethodException =>
             }
-          }: Runnable, "landlord-trap"
+          }: Runnable, s"${context.system.name}-trap"
           ).start()
           if (signal == SIGABRT || signal == SIGINT || signal == SIGTERM)
             timers.startSingleTimer("signalCheck", Stop, exitTimeout)
+        } catch {
+          case NonFatal(_) => // There's still a chance that starting the trap thread can fail
         }
-      } catch {
-        case NonFatal(_) => // There's still a chance that starting the trap thread can fail
       }
 
-    case SignalProcessEot =>
+    case ConnectionReadClosed =>
       try {
         new Thread(
-          processThreadGroup, { () => stdin.signalClose() }, "landlord-eot"
+          processThreadGroup, { () => stdin.signalClose() }, s"${context.system.name}-eot"
         ).start()
       } catch {
         case NonFatal(_) => // All we can do is try
       }
 
+    case ConnectionWriteClosed =>
+      if (stopInProgress.get) {
+        self ! Stop
+      } else {
+        self ! SignalProcess(SIGINT)
+      }
+
     case Stop =>
-      val remainingThreads = activeThreads(processThreadGroup)
+      val remainingThreads = activeThreads(processThreadGroup).filterNot(_.getName.startsWith(context.system.name))
       val remainingThreadCount = remainingThreads.size
       if (remainingThreadCount > 0)
         log.error(

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -27,7 +27,8 @@ object Main extends App {
       outputDrainTimeAtExit: FiniteDuration = 100.milliseconds,
       processDirPath: Path = Files.createTempDirectory("jvm-executor"),
       stdinTimeout: FiniteDuration = 1.hour,
-      useDefaultSecurityManager: Boolean = false
+      useDefaultSecurityManager: Boolean = false,
+      heartbeatInterval: FiniteDuration = 1.second
   )
 
   val parser = new scopt.OptionParser[Config](Version.executableScriptName) {
@@ -228,6 +229,7 @@ object Main extends App {
           stdin, config.stdinTimeout, stdout, stderr,
           in, out,
           config.exitTimeout, config.outputDrainTimeAtExit,
+          config.heartbeatInterval,
           config.processDirPath.resolve(processId.toString)
         )
       }
@@ -244,7 +246,6 @@ object Main extends App {
                 system.log.debug("New unix connection {}", connection)
 
                 connection.handleWith(controlFlow(reaper, launchInfoOp, sendKillOp))
-
               })(Keep.left)
               .run
 

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -116,6 +116,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
           stdin, 3.seconds.dilated, stdout, stderr,
           in, out,
           12.seconds.dilated, 100.milliseconds.dilated,
+          1.second,
           processDirPath
         ))
 

--- a/landlordd/test/src/main/java/example/Hello.java
+++ b/landlordd/test/src/main/java/example/Hello.java
@@ -49,7 +49,6 @@ public class Hello {
 
     @SuppressWarnings("unused")
     public static void trap(int signal) {
-        System.out.println("Trapped: " + signal);
         if ((signal & 0xf) > 0)             // Terminate
           System.exit(128 + signal); // As per the convention of exit codes
     }


### PR DESCRIPTION
Due to a more recent change, the process was not being shut down upon having lost its client connection. If a client shuts down ungracefully then the process would continue to run. This commit re-instates the issuing of a SIGINT signal upon the client connection having been lost.

Stopping has also been improved such that checks for unrelinquished resources are always made, whether stopping via a signal or not.

Another big one was waiting for termination. We must wait for threads to terminate before removing the class loader in particular. Prior to my change here, the shutdown of a process could suddenly have its class loader removed from underneath it. Not pretty!

Lastly, some strengthening of best-effort actions i.e. attempting to invoke a trap handler and signalling EOT.