### PR TITLE
Ammend pr #49

### DIFF
--- a/landlord/src/proto.rs
+++ b/landlord/src/proto.rs
@@ -4,7 +4,6 @@ use std::io::prelude::*;
 
 pub enum Input {
     Exit(i32),
-    Fail(io::Error),
     Signal(i32),
     StdIn(Vec<u8>),
     StdInClosed,
@@ -41,10 +40,6 @@ where
         match reader() {
             Ok(Input::Exit(s)) => {
                 return Ok(s);
-            }
-
-            Ok(Input::Fail(e)) => {
-                return Err(e);
             }
 
             Ok(Input::StdIn(b)) => {

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -27,7 +27,8 @@ object Main extends App {
       outputDrainTimeAtExit: FiniteDuration = 100.milliseconds,
       processDirPath: Path = Files.createTempDirectory("jvm-executor"),
       stdinTimeout: FiniteDuration = 1.hour,
-      useDefaultSecurityManager: Boolean = false
+      useDefaultSecurityManager: Boolean = false,
+      processDeadAfter: FiniteDuration = 10.seconds, processDeadPollInterval: FiniteDuration = 1.second
   )
 
   val parser = new scopt.OptionParser[Config](Version.executableScriptName) {
@@ -228,6 +229,7 @@ object Main extends App {
           stdin, config.stdinTimeout, stdout, stderr,
           in, out,
           config.exitTimeout, config.outputDrainTimeAtExit,
+          config.processDeadAfter, config.processDeadPollInterval,
           config.processDirPath.resolve(processId.toString)
         )
       }

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -116,6 +116,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
           stdin, 3.seconds.dilated, stdout, stderr,
           in, out,
           12.seconds.dilated, 100.milliseconds.dilated,
+          10.seconds, 1.second,
           processDirPath
         ))
 


### PR DESCRIPTION
*Note: This is a PR on your branch, not `master`*

* Fixes race condition causing test to fail due to waiting for `Thread[JvmExecutorSpec-akka.stream.default-blocking-io-dispatcher-26,5,process-group-123]` to finish. Now, we identify threads based on the actor system's name instead (which for `landlordd` ultimately behaves the same since it's actor system name is `landlord`).

* Adds a heartbeat mechanism instead of assuming EOT means the process has died (which isn't true, consider e.g. an environment without a TTY). This is done by reusing the UNIX signal mechanism that's already in place. The downside is the signal `-2147483648` no longer can be used by the application. One alternative is that we could change the signal type to 64bit, and reserve 32bits of that for our own purposes (this being one). A different alternative is to add another mechanism separate from signals and use that, e.g. `h` for heartbeat.