### PR TITLE
Improve closed connection handling

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/Main.scala
@@ -27,7 +27,8 @@ object Main extends App {
       outputDrainTimeAtExit: FiniteDuration = 100.milliseconds,
       processDirPath: Path = Files.createTempDirectory("jvm-executor"),
       stdinTimeout: FiniteDuration = 1.hour,
-      useDefaultSecurityManager: Boolean = false
+      useDefaultSecurityManager: Boolean = false,
+      heartbeatInterval: FiniteDuration = 1.second
   )
 
   val parser = new scopt.OptionParser[Config](Version.executableScriptName) {
@@ -228,6 +229,7 @@ object Main extends App {
           stdin, config.stdinTimeout, stdout, stderr,
           in, out,
           config.exitTimeout, config.outputDrainTimeAtExit,
+          config.heartbeatInterval,
           config.processDirPath.resolve(processId.toString)
         )
       }
@@ -244,7 +246,6 @@ object Main extends App {
                 system.log.debug("New unix connection {}", connection)
 
                 connection.handleWith(controlFlow(reaper, launchInfoOp, sendKillOp))
-
               })(Keep.left)
               .run
 

--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -116,6 +116,7 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
           stdin, 3.seconds.dilated, stdout, stderr,
           in, out,
           12.seconds.dilated, 100.milliseconds.dilated,
+          1.second,
           processDirPath
         ))
 


### PR DESCRIPTION
I think I like this a bit more. We use keepAlive to periodically emit empty stdout messages to the client, which allows the server to determine when the connection is truly closed.

However, it's only working for TCP right now. I think there's a bug in the unix domain socket connector in Alpakka.

Will discuss both approaches at standup.