### PR TITLE
Explicitly inherit props

### DIFF
--- a/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
+++ b/landlordd/daemon/src/test/scala/com/github/huntc/landlord/JvmExecutorSpec.scala
@@ -117,7 +117,8 @@ class JvmExecutorSpec extends TestKit(ActorSystem("JvmExecutorSpec"))
           in, out,
           12.seconds.dilated, 100.milliseconds.dilated,
           1.second,
-          processDirPath
+          processDirPath,
+          List.empty
         ))
 
       val outputOk =


### PR DESCRIPTION
This commit introduces an explicit means by which an operator can declare which, if any, of Landlord's properties, should appear in a process.

All of Landlord's props were being provided as defaults to a process. This may not be secure. In addition, calls to System.getProperties() would omit the default properties, which would also then cause Typesafe Config to fail for some scenarios that we have.

Tested against one of our Akka services. Seems to work well.